### PR TITLE
Added +finger command

### DIFF
--- a/commands/CmdFinger.py
+++ b/commands/CmdFinger.py
@@ -1,0 +1,141 @@
+from evennia.commands.default.muxcommand import MuxCommand
+from world.wod20th.models import Stat, CATEGORIES, SHIFTER_IDENTITY_STATS, SHIFTER_RENOWN, CLAN, MAGE_FACTION, MAGE_SPHERES, \
+    TRADITION, TRADITION_SUBFACTION, CONVENTION, METHODOLOGIES, NEPHANDI_FACTION, SEEMING, KITH, SEELIE_LEGACIES, \
+    UNSEELIE_LEGACIES, ARTS, REALMS, calculate_willpower, calculate_road
+from world.wod20th.utils.ansi_utils import wrap_ansi
+from world.wod20th.utils.formatting import header, format_idle_time, get_idle_time, footer, divider, english_list
+
+class CmdFinger(MuxCommand):
+    """
+    Settable details about a character and their player's roleplay preferences
+
+    Possible settable fields:
+      rumors         - Common knowledge about your character
+      hangouts       - Where people can find your character
+      rp preferences - Themes you like or want to avoid
+      ic job         - Where your character works
+      online times   - Days/times you can be found available for RP
+      quotes         - Funtime quotes
+      notes          - Other information not fitting to other fields about character
+
+    Usage:
+      +finger
+      +finger/show <stat>/<category>
+      +finger/hide <stat>/<category>
+      +finger/set <field>=<value>
+      +finger <character>
+
+    Switches:
+      /set      - Set a field on your finger profile
+      /show     - Show a stat from your sheet
+      /hide     - Hide a stat from your sheet
+
+    Examples:
+      +finger                       - View your own finger profile for your current character
+      +finger/show appearance       - Display your appearance stat on your finger
+    """
+    key = "finger"
+    aliases = []
+    help_category = "Chargen & Character Info"
+    long_fields = ["rumors", "hangouts", "rp preferences", "ic job", "online times", "quotes", "notes"]
+
+    def func(self):
+        character = self.caller.search(self.caller.key)
+        if not self.args and not self.switches:
+            self.show_finger(character)
+        elif "show" in self.switches:
+            matched_stat = Stat.objects.filter(name__iexact=self.args.strip())
+            if not matched_stat.exists():
+                return self.caller.msg(f"Unable to find a stat matching '{self.args.strip()}'.")
+            character_stats = character.db.stats or {}
+            if matched_stat[0].category not in character_stats or matched_stat[0].stat_type not in character_stats[matched_stat[0].category]:
+                return self.caller.msg(f"Unable to find a stat matching '{self.args.strip()}' on your sheet.")
+            self.add_shown_stat(character, matched_stat[0])
+            self.caller.msg(f"Your +finger will now show the value of '{matched_stat[0].name}'.")
+        elif "hide" in self.switches:
+            matched_stat = Stat.objects.filter(name__iexact=self.args.strip())
+            if not matched_stat.exists():
+                return self.caller.msg(f"Unable to find a stat matching '{self.args.strip()}'.")
+            if matched_stat[0].category not in character.db.dossier['shown_stats'] or matched_stat[0].name not in character.db.dossier['shown_stats'][matched_stat[0].category]:
+                return self.caller.msg(f"You are not currently showing '{matched_stat[0].name}' on your +finger.")
+            self.remove_shown_stat(character, matched_stat[0])
+            self.caller.msg(f"Your +finger is no longer showing your '{matched_stat[0].name}'.")
+        elif "set" in self.switches:
+            try:
+                key, value = self.split_key_value(self.args)
+                if key not in self.long_fields:
+                    return self.caller.msg(f"Unrecognized field '{key}', fields must be one of: {english_list(self.long_fields, 'none', ' or ')}.")
+                if not value:
+                    del character.db.dossier[key]
+                    return self.caller.msg(f"Successfully deleted field {key} from your +finger.")
+                character.db.dossier[key] = value
+                self.caller.msg(f"Successfully set +finger {key} to: {value}")
+            except ValueError as e:
+                self.caller.msg(e)
+            
+    def split_key_value(self, input_string):
+        try:
+            # Split the string on '='
+            key, value = input_string.split('=', 1)  # Split at the first '='
+            key = key.strip()
+            value = value.strip()
+            return key, value
+        except ValueError:
+            # Handle cases where '=' is missing or improperly formatted
+            raise ValueError("Input must be in the format 'key=value'.")
+    
+    def add_shown_stat(self, character, stat):
+        """
+        Adds a stat to the specified category in shown_stats.
+        Creates the category if it doesn't exist.
+        """
+        if stat.category not in character.db.dossier['shown_stats']:
+            character.db.dossier['shown_stats'][stat.category] = []
+        if stat not in character.db.dossier['shown_stats'][stat.category]:
+            character.db.dossier['shown_stats'][stat.category].append(stat.name)\
+
+    def remove_shown_stat(self, character, stat):
+        """
+        Removes a stat from the specified category in shown_stats.
+        Automatically removes the category if it becomes empty.
+        """
+        if stat.category not in character.db.dossier['shown_stats']:
+            return
+        if stat.name not in character.db.dossier['shown_stats'][stat.category]:
+            return
+        character.db.dossier['shown_stats'][stat.category].remove(stat.name)
+        # Automatically delete the category if it becomes empty
+        if not character.db.dossier['shown_stats'][stat.category]:
+            del character.db.dossier['shown_stats'][stat.category]
+
+    def show_finger(self, character):
+        def format_stat(stat, value, filler=".", width=38):
+            # Special case for 'Traditions Subfaction'
+            display_stat = 'Subfaction' if stat == 'Traditions Subfaction' else stat
+            
+            stat_str = f" {display_stat}"
+            value_str = f"{value}"
+            dots = filler * (width - len(stat_str) - len(value_str) - 1)
+            return f"|w{stat_str}|n{dots}{value_str}"
+        dossier = character.get_dossier()
+        
+        string = header(f"{character.name}'s +finger")
+        string += format_stat("Full Name:", "Meowdy", " ")
+        string += "  " + format_stat("Idle:", f"|g{format_idle_time(get_idle_time(character))}|n", " ", 42) + "\r\n"
+        string += format_stat("Status:", "|gApproved|n" if character.tags.has("approved") else "|rNot Approved|n", " ", 42) + "\r\n"
+        if any(key in dossier for key in self.long_fields):
+            string += divider("Info") + "\r\n"
+            for key in self.long_fields:
+                if key not in dossier:
+                    continue
+                string += f" |w{key.capitalize().ljust(20)}:|n {wrap_ansi(dossier[key], width=56)}\r\n"
+        character_stats = character.db.stats or {}
+        for category, stats in dossier['shown_stats'].items():
+            string += divider(category.capitalize()) + "\r\n"
+            for stat in stats:
+                stat_obj = Stat.objects.filter(name__iexact=stat, category__iexact=category)[0]
+                if category not in character_stats or stat_obj.stat_type not in character_stats[category]:
+                    continue
+                string += format_stat(stat_obj.name, character_stats[category][stat_obj.stat_type][stat_obj.name]['perm']) + "\r\n"
+        string += footer()
+        self.caller.msg(string)

--- a/commands/CmdSelfStat.py
+++ b/commands/CmdSelfStat.py
@@ -161,8 +161,13 @@ class CmdSelfStat(default_cmds.MuxCommand):
         # Update the stat
         character.set_stat(stat.category, stat.stat_type, full_stat_name, new_value, temp=False)
         
-        # If the stat is in the 'pools' category or has a 'dual' stat_type, update the temporary value as well
-        if stat.category == 'pools' or stat.stat_type == 'dual':
+        # During character generation (when character is not approved), 
+        # always set temp value equal to permanent value
+        if not character.db.approved:
+            character.set_stat(stat.category, stat.stat_type, full_stat_name, new_value, temp=True)
+            self.caller.msg(f"|gUpdated {full_stat_name} to {new_value} (both permanent and temporary).|n")
+        # If already approved, only update temp for pools and dual stats
+        elif stat.category == 'pools' or stat.stat_type == 'dual':
             character.set_stat(stat.category, stat.stat_type, full_stat_name, new_value, temp=True)
             self.caller.msg(f"|gUpdated {full_stat_name} to {new_value} (both permanent and temporary).|n")
         else:

--- a/commands/CmdSetStats.py
+++ b/commands/CmdSetStats.py
@@ -247,14 +247,20 @@ class CmdStats(default_cmds.MuxCommand):
         # Update the stat
         character.set_stat(stat.category, stat.stat_type, full_stat_name, new_value, temp=False)
         
-        # If the stat is in the 'pools' category or has a 'dual' stat_type, update the temporary value as well
-        if stat.category == 'pools' or stat.stat_type == 'dual':
+        # During character generation (when character is not approved), 
+        # always set temp value equal to permanent value
+        if not character.db.approved:
             character.set_stat(stat.category, stat.stat_type, full_stat_name, new_value, temp=True)
             self.caller.msg(f"|gUpdated {character.name}'s {full_stat_name} to {new_value} (both permanent and temporary).|n")
-            character.msg(f"|y{self.caller.name}|n |gupdated your|n '|y{full_stat_name}|n' |gto|n '|y{new_value}|n' |g(both permanent and temporary).|n")
+            character.msg(f"|y{self.caller.name}|n |gset your {full_stat_name} to {new_value} (both permanent and temporary).|n")
+        # If already approved, only update temp for pools and dual stats
+        elif stat.category == 'pools' or stat.stat_type == 'dual':
+            character.set_stat(stat.category, stat.stat_type, full_stat_name, new_value, temp=True)
+            self.caller.msg(f"|gUpdated {character.name}'s {full_stat_name} to {new_value} (both permanent and temporary).|n")
+            character.msg(f"|y{self.caller.name}|n |gset your {full_stat_name} to {new_value} (both permanent and temporary).|n")
         else:
             self.caller.msg(f"|gUpdated {character.name}'s {full_stat_name} to {new_value}.|n")
-            character.msg(f"|y{self.caller.name}|n |gupdated your|n '|y{full_stat_name}|n' |gto|n '|y{new_value}|n'.")
+            character.msg(f"|y{self.caller.name}|n |gset your {full_stat_name} to {new_value}.|n")
 
         # If the stat is 'Type' for a Shifter, apply the correct pools and renown
         if full_stat_name == 'Type' and character.get_stat('other', 'splat', 'Splat').lower() == 'shifter':

--- a/commands/CmdSheet.py
+++ b/commands/CmdSheet.py
@@ -442,10 +442,11 @@ class CmdSheet(MuxCommand):
         for power, advantage, status_line in zip(powers, advantages, status):
             string += f"{power.strip().ljust(25)} {advantage.strip().ljust(25)} {status_line.strip().ljust(25)}\n"
 
-        if not character.db.approved:
-            string += footer()
-            string += header("Unapproved Character", width=78, color="|y")
-        string += footer()
+        # Check approval status
+        if character.db.approved:
+            string += header("Approved Character", width=78, fillchar="-")
+        else:
+            string += header("Unapproved Character", width=78, fillchar="-")
 
         self.caller.msg(string)
 

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -27,6 +27,7 @@ import evennia.contrib.game_systems.mail as mail
 from  commands.CmdRoll import CmdRoll
 from commands.CmdSay import CmdSay
 from commands.CmdEmit import CmdEmit
+from commands.CmdFinger import CmdFinger
 from commands.CmdNotes import CmdNotes
 from commands.bbs.bbs_cmdset import BBSCmdSet
 from commands.building import CmdSetRoomResources, CmdSetRoomType, CmdSetUmbraDesc, CmdSetGauntlet, CmdUmbraInfo
@@ -84,6 +85,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdEvents())
         self.add(mail.CmdMail())
         self.add(mail.CmdMailCharacter())
+        self.add(CmdFinger())
         self.add(CmdRoll())
         self.add(CmdShift())
         self.add(CmdWeather())

--- a/commands/where.py
+++ b/commands/where.py
@@ -1,8 +1,7 @@
 from evennia import default_cmds
 from evennia.server.sessionhandler import SESSIONS
 from evennia.utils.ansi import ANSIString
-from world.wod20th.utils.formatting import header
-import time
+from world.wod20th.utils.formatting import header, format_idle_time, get_idle_time
 
 class CmdWhere(default_cmds.MuxCommand):
     """
@@ -20,32 +19,6 @@ class CmdWhere(default_cmds.MuxCommand):
     locks = "cmd:all()"
     help_category = "General"
 
-    def format_idle_time(self, idle_seconds):
-        """
-        Formats the idle time into human-readable format.
-        """
-        if idle_seconds < 60:
-            return f"{int(idle_seconds)}s"
-        elif idle_seconds < 3600:
-            return f"{int(idle_seconds / 60)}m"
-        elif idle_seconds < 86400:
-            return f"{int(idle_seconds / 3600)}h"
-        elif idle_seconds < 604800:
-            return f"{int(idle_seconds / 86400)}d"
-        else:
-            return f"{int(idle_seconds / 604800)}w"
-
-    def get_idle_time(self, character):
-        """
-        Get the idle time for a character.
-        """
-        if not character.sessions.count():
-            return 0
-        sessions = character.sessions.all()
-        if sessions:
-            return time.time() - max(session.cmd_last_visible for session in sessions)
-        return 0
-
     def func(self):
         """
         Implement the command.
@@ -60,7 +33,7 @@ class CmdWhere(default_cmds.MuxCommand):
                 continue
             character = session.puppet
             if character:
-                idle_time = self.format_idle_time(self.get_idle_time(character))
+                idle_time = format_idle_time(get_idle_time(character))
                 if character.location and not character.db.unfindable and not character.location.db.unfindable:
                     location = character.location.get_display_name(self.caller)
                     location = location[:40]  # Shortened to accommodate Umbra status

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -76,6 +76,9 @@ class Character( DefaultCharacter):
         self.db.speaking_language = None
         self.db.approved = False
         self.db.in_umbra = False  # Use a persistent attribute instead of a tag
+        self.db.dossier = {
+            'shown_stats': {} # Structure: {category: [stats]}
+        } # used for finger/wiki info
 
     @lazy_property
     def notes(self):
@@ -115,6 +118,13 @@ class Character( DefaultCharacter):
             note.save()
             return True
         return False
+    
+    def get_dossier(self):
+        if not self.db.dossier:
+            self.db.dossier = { 'shown_stats': {} }
+        if not self.db.dossier['shown_stats']:
+            self.db.dossier['shown_stats'] = {}
+        return self.db.dossier
 
     def get_display_name(self, looker, **kwargs):
         """
@@ -133,7 +143,7 @@ class Character( DefaultCharacter):
             name += f"({self.dbref})"
 
         return name
-
+    
     def get_languages(self):
         """
         Get the character's known languages.

--- a/world/wod20th/utils/formatting.py
+++ b/world/wod20th/utils/formatting.py
@@ -1,4 +1,5 @@
 from evennia.utils.ansi import ANSIString
+import time
 
 def format_stat(stat, value, width=25, default=None, tempvalue=None, allow_zero=False):
     """Format a stat for display with proper spacing and temporary values."""
@@ -38,7 +39,6 @@ def header(title, width=78,  color="|y", fillchar=ANSIString("|b-|n"), bcolor="|
 def footer(width=78, fillchar=ANSIString("|b-|n")):
     return ANSIString(fillchar) * width + "\n"
 
-
 def divider(title, width=78, fillchar="-", color="|r", text_color="|n"):
     """
     Create a divider with a title.
@@ -77,3 +77,39 @@ def divider(title, width=78, fillchar="-", color="|r", text_color="|n"):
 
     # Remove any trailing whitespace and add the color terminator
     return ANSIString(f"{inner_content.rstrip()}|n")
+
+def format_idle_time(idle_seconds):
+        """
+        Formats the idle time into human-readable format.
+        """
+        if idle_seconds < 60:
+            return f"{int(idle_seconds)}s"
+        elif idle_seconds < 3600:
+            return f"{int(idle_seconds / 60)}m"
+        elif idle_seconds < 86400:
+            return f"{int(idle_seconds / 3600)}h"
+        elif idle_seconds < 604800:
+            return f"{int(idle_seconds / 86400)}d"
+        else:
+            return f"{int(idle_seconds / 604800)}w"
+
+def get_idle_time(character):
+    """
+    Get the idle time for a character.
+    """
+    if not character.sessions.count():
+        return 0
+    sessions = character.sessions.all()
+    if sessions:
+        return time.time() - max(session.cmd_last_visible for session in sessions)
+    return 0
+
+def english_list(items, none_str="None", join_str=" and ", comma_str=", "):
+    if not items:
+        return none_str  # Return an empty string for an empty list
+    if len(items) == 1:
+        return items[0]  # Return the single item
+    if len(items) == 2:
+        return join_str.join(items)  # Join with "and" for two items
+    # Join all but the last item with commas, and append the last item with "and"
+    return comma_str.join(items[:-1]) + comma_str.strip() + join_str + items[-1]


### PR DESCRIPTION
```
Settable details about a character and their player's roleplay preferences

    Possible settable fields:
      rumors         - Common knowledge about your character
      hangouts       - Where people can find your character
      rp preferences - Themes you like or want to avoid
      ic job         - Where your character works
      online times   - Days/times you can be found available for RP
      quotes         - Funtime quotes
      notes          - Other information not fitting to other fields about character

    Usage:
      +finger
      +finger/show <stat>/<category>
      +finger/hide <stat>/<category>
      +finger/set <field>=<value>
      +finger <character>

    Switches:
      /set      - Set a field on your finger profile
      /show     - Show a stat from your sheet
      /hide     - Hide a stat from your sheet

    Examples:
      +finger                       - View your own finger profile for your current character
      +finger/show appearance       - Display your appearance stat on your finger
```