### PR TITLE
A Quiet Place

### DIFF
--- a/commands/CmdEmit.py
+++ b/commands/CmdEmit.py
@@ -38,6 +38,11 @@ class CmdEmit(PoseBreakMixin, default_cmds.MuxCommand):
     def func(self):
         """Execute the @emit command"""
         caller = self.caller
+        
+        # Check if the room is a Quiet Room
+        if hasattr(caller.location, 'db') and caller.location.db.roomtype == "Quiet Room":
+            caller.msg("|rYou are in a Quiet Room and cannot emit messages.|n")
+            return
 
         if not self.args:
             caller.msg("Usage: @emit <message>")

--- a/commands/CmdPose.py
+++ b/commands/CmdPose.py
@@ -90,6 +90,12 @@ class CmdPose(PoseBreakMixin, default_cmds.MuxCommand):
 
     def func(self):
         caller = self.caller
+        
+        # Check if the room is a Quiet Room
+        if hasattr(caller.location, 'db') and caller.location.db.roomtype == "Quiet Room":
+            caller.msg("|rYou are in a Quiet Room and cannot pose.|n")
+            return
+            
         if not self.args:
             caller.msg("Pose what?")
             return

--- a/commands/CmdSay.py
+++ b/commands/CmdSay.py
@@ -26,6 +26,11 @@ class CmdSay(PoseBreakMixin, MuxCommand):
         """
         caller = self.caller
 
+        # Check if the room is a Quiet Room
+        if hasattr(caller.location, 'db') and caller.location.db.roomtype == "Quiet Room":
+            caller.msg("|rYou are in a Quiet Room and cannot speak.|n")
+            return
+
         if not self.args:
             caller.msg("Say what?")
             return

--- a/commands/communication.py
+++ b/commands/communication.py
@@ -43,6 +43,11 @@ class CmdOOC(MuxCommand):
     help_category = "Comms"
 
     def func(self):
+        # Check if the room is a Quiet Room
+        if hasattr(self.caller.location, 'db') and self.caller.location.db.roomtype == "Quiet Room":
+            self.caller.msg("|rYou are in a Quiet Room and cannot use OOC communication.|n")
+            return
+            
         if not self.args:
             self.caller.msg("Say or pose what?")
             return
@@ -159,7 +164,7 @@ class CmdPlusOoc(MuxCommand):
         caller.db.pre_ooc_location = current_location
 
         # Find Limbo (object #1729)
-        ooc_nexus = search_object("#2")[0]
+        ooc_nexus = search_object("#1729")[0]
 
         if not ooc_nexus:
             caller.msg("Error: ooc_nexus not found.")

--- a/typeclasses/exits.py
+++ b/typeclasses/exits.py
@@ -220,12 +220,20 @@ class Exit(DefaultExit):
             if hasattr(traversing_object, 'msg'):
                 traversing_object.msg(f"You cannot traverse {self.key}.")
             return False
-        """Called when an object tries to use the exit."""
+            
         # Check if current location prevents exit use
         if hasattr(traversing_object.location, "prevent_exit_use"):
-            if traversing_object.location.prevent_exit_use(self, traversing_object):
-                return False        
+            try:
+                if traversing_object.location.prevent_exit_use(self, traversing_object):
+                    return False
+            except Exception as e:
+                # Log error but don't crash
+                logger.log_err(f"Error in prevent_exit_use: {e}")
+                if hasattr(traversing_object, 'msg'):
+                    traversing_object.msg("There was an error processing your movement. Please try again.")
+                return False
             
+        # Call parent's at_traverse
         return super().at_traverse(traversing_object, target_location, **kwargs)
     
     def at_failed_traverse(self, traversing_object, **kwargs):


### PR DESCRIPTION
This updates the room and exit typeclasses to suppress comings and goings from rooms marked with the room_type of 'Quiet Room.' Additionally, the commands 'Say' 'Pose', 'Emit', and 'OOC' are restricted from use when in a room with the typeclass of 'Quiet Room'.