### PR TITLE
The Bear Necessities Update (4/16/25)

### DIFF
--- a/commands/CmdChangelingInteraction.py
+++ b/commands/CmdChangelingInteraction.py
@@ -24,6 +24,13 @@ class CmdChangelingInteraction(MuxCommand):
 
     def func(self):
         """Execute command."""
+        # Check if in a Quiet Room
+        if (hasattr(self.caller.location, 'db') and 
+            hasattr(self.caller.location, 'is_command_restricted_in_quiet_room') and
+            self.caller.location.is_command_restricted_in_quiet_room(self.cmdstring)):
+            self.caller.msg("|rYou are in a Quiet Room and cannot use fae interaction commands here.|n")
+            return
+            
         splat = self.caller.db.stats['other']['splat'].get('Splat', {}).get('perm', '')
         
         # Check if character is either a Changeling or Kinain

--- a/commands/CmdHurt.py
+++ b/commands/CmdHurt.py
@@ -53,15 +53,26 @@ class CmdHurt(Command):
 
         damage_type_full = {'b': 'bashing', 'l': 'lethal', 'a': 'aggravated'}[damage_type]
         
+        # Initialize health_level_bonuses if it doesn't exist
+        if not hasattr(target.db, 'health_level_bonuses') or target.db.health_level_bonuses is None:
+            target.db.health_level_bonuses = {
+                'bruised': 0,
+                'hurt': 0,
+                'injured': 0,
+                'wounded': 0,
+                'mauled': 0,
+                'crippled': 0
+            }
+        
         # Calculate total health levels including bonuses
-        base_health = 7
-        bonus_health = calculate_total_health_levels(target)
-        total_health = base_health + bonus_health
+        total_health = calculate_total_health_levels(target)
 
         # Apply damage
         apply_damage_or_healing(target, damage, damage_type_full)
 
         # Ensure damage doesn't exceed maximum health
+        base_health = target.get_stat('other', 'other', 'Health') or 7
+        total_health = base_health + total_health
         if target.db.agg > total_health:
             target.db.agg = total_health
 

--- a/commands/CmdSheet.py
+++ b/commands/CmdSheet.py
@@ -338,21 +338,24 @@ class CmdSheet(MuxCommand):
         if splat == 'Mortal+':
             return get_mortalplus_identity_stats(char_type)
         
-        # Get tribe for Garou characters
+        # Get tribe for all appropriate Shifter types
         tribe = None
-        if char_type and char_type.lower() == 'garou':
-            tribe = character.get_stat('identity', 'lineage', 'Tribe', temp=False)
-            # Get base stats from get_identity_stats
-            stats = get_identity_stats(splat, char_type, tribe)
-            
-            # Special handling for Silver Fangs
-            if tribe and tribe.lower() == 'silver fangs':
-                # Remove 'Camp' if it's in the list
-                if 'Camp' in stats:
-                    stats.remove('Camp')
-                # Add Silver Fang specific stats
-                stats.extend(['Fang House', 'Lodge'])
-            return stats
+        if char_type and splat == 'Shifter':
+            # These shifter types all have tribes
+            shifter_types_with_tribes = ['garou', 'gurahl', 'bastet', 'rokea']
+            if char_type.lower() in shifter_types_with_tribes:
+                tribe = character.get_stat('identity', 'lineage', 'Tribe', temp=False)
+                # Get base stats from get_identity_stats
+                stats = get_identity_stats(splat, char_type, tribe)
+                
+                # Special handling for Silver Fangs
+                if tribe and char_type.lower() == 'garou' and tribe.lower() == 'silver fangs':
+                    # Remove 'Camp' if it's in the list
+                    if 'Camp' in stats:
+                        stats.remove('Camp')
+                    # Add Silver Fang specific stats
+                    stats.extend(['Fang House', 'Lodge'])
+                return stats
         
         # Special handling for Mage characters
         if splat == 'Mage':
@@ -1119,6 +1122,33 @@ class CmdSheet(MuxCommand):
                     discipline_value = values.get('perm', 0)
                     powers.append(format_stat(discipline, discipline_value, default=0, width=self.POWERS_WIDTH))
 
+            # Process sorcery
+            sorcery = character.db.stats.get('powers', {}).get('sorcery', {})
+            if sorcery:
+                powers.append(" " * 38)  # Add spacing
+                powers.append(divider("Sorcery", width=38, color="|b"))
+                for power, values in sorted(sorcery.items()):
+                    power_value = values.get('perm', 0)
+                    powers.append(format_stat(power, power_value, default=0, width=self.POWERS_WIDTH))
+
+            # Process numina
+            numina = character.db.stats.get('powers', {}).get('numina', {})
+            if numina:
+                powers.append(" " * 38)  # Add spacing
+                powers.append(divider("Numina", width=38, color="|b"))
+                for power, values in sorted(numina.items()):
+                    power_value = values.get('perm', 0)
+                    powers.append(format_stat(power, power_value, default=0, width=self.POWERS_WIDTH))
+
+            # Process hedge rituals
+            hedge_rituals = character.db.stats.get('powers', {}).get('hedge_ritual', {})
+            if hedge_rituals:
+                powers.append(" " * 38)  # Add spacing
+                powers.append(divider("Hedge Rituals", width=38, color="|b"))
+                for ritual, values in sorted(hedge_rituals.items()):
+                    ritual_value = values.get('perm', 0)
+                    powers.append(format_stat(ritual, ritual_value, default=0, width=self.POWERS_WIDTH))
+
         elif mortalplus_type.lower() == 'kinfolk':
             # Process gifts
             gifts = character.db.stats.get('powers', {}).get('gift', {})
@@ -1134,6 +1164,33 @@ class CmdSheet(MuxCommand):
                 for rite, values in sorted(rites.items()):
                     rite_value = values.get('perm', 0)
                     powers.append(format_stat(rite, rite_value, default=0, width=self.POWERS_WIDTH))
+            
+            # Process sorcery
+            sorcery = character.db.stats.get('powers', {}).get('sorcery', {})
+            if sorcery:
+                powers.append(" " * 38)  # Add spacing
+                powers.append(divider("Sorcery", width=38, color="|b"))
+                for power, values in sorted(sorcery.items()):
+                    power_value = values.get('perm', 0)
+                    powers.append(format_stat(power, power_value, default=0, width=self.POWERS_WIDTH))
+
+            # Process numina
+            numina = character.db.stats.get('powers', {}).get('numina', {})
+            if numina:
+                powers.append(" " * 38)  # Add spacing
+                powers.append(divider("Numina", width=38, color="|b"))
+                for power, values in sorted(numina.items()):
+                    power_value = values.get('perm', 0)
+                    powers.append(format_stat(power, power_value, default=0, width=self.POWERS_WIDTH))
+
+            # Process hedge rituals
+            hedge_rituals = character.db.stats.get('powers', {}).get('hedge_ritual', {})
+            if hedge_rituals:
+                powers.append(" " * 38)  # Add spacing
+                powers.append(divider("Hedge Rituals", width=38, color="|b"))
+                for ritual, values in sorted(hedge_rituals.items()):
+                    ritual_value = values.get('perm', 0)
+                    powers.append(format_stat(ritual, ritual_value, default=0, width=self.POWERS_WIDTH))
 
         elif mortalplus_type.lower() == 'kinain':
             # Process arts
@@ -1143,6 +1200,33 @@ class CmdSheet(MuxCommand):
                 for art, values in sorted(arts.items()):
                     art_value = values.get('perm', 0)
                     powers.append(format_stat(art, art_value, default=0, width=self.POWERS_WIDTH))
+
+            # Process sorcery
+            sorcery = character.db.stats.get('powers', {}).get('sorcery', {})
+            if sorcery:
+                powers.append(" " * 38)  # Add spacing
+                powers.append(divider("Sorcery", width=38, color="|b"))
+                for power, values in sorted(sorcery.items()):
+                    power_value = values.get('perm', 0)
+                    powers.append(format_stat(power, power_value, default=0, width=self.POWERS_WIDTH))
+
+            # Process numina
+            numina = character.db.stats.get('powers', {}).get('numina', {})
+            if numina:
+                powers.append(" " * 38)  # Add spacing
+                powers.append(divider("Numina", width=38, color="|b"))
+                for power, values in sorted(numina.items()):
+                    power_value = values.get('perm', 0)
+                    powers.append(format_stat(power, power_value, default=0, width=self.POWERS_WIDTH))
+
+            # Process hedge rituals
+            hedge_rituals = character.db.stats.get('powers', {}).get('hedge_ritual', {})
+            if hedge_rituals:
+                powers.append(" " * 38)  # Add spacing
+                powers.append(divider("Hedge Rituals", width=38, color="|b"))
+                for ritual, values in sorted(hedge_rituals.items()):
+                    ritual_value = values.get('perm', 0)
+                    powers.append(format_stat(ritual, ritual_value, default=0, width=self.POWERS_WIDTH))
 
             # Add spacing between sections if both arts and realms exist
             if arts and character.db.stats.get('powers', {}).get('realm', {}):
@@ -1177,6 +1261,13 @@ class CmdSheet(MuxCommand):
                     ritual_value = values.get('perm', 0)
                     powers.append(format_stat(ritual, ritual_value, default=0, width=self.POWERS_WIDTH))
 
+            numina = character.db.stats.get('powers', {}).get('numina', {})
+            if numina:
+                powers.append(divider("Numina", width=38, color="|b"))
+                for power, values in sorted(numina.items()):
+                    power_value = values.get('perm', 0)
+                    powers.append(format_stat(power, power_value, default=0, width=self.POWERS_WIDTH))
+
         elif mortalplus_type.lower() == 'psychic':
             # Process numina
             numina = character.db.stats.get('powers', {}).get('numina', {})
@@ -1186,6 +1277,23 @@ class CmdSheet(MuxCommand):
                     power_value = values.get('perm', 0)
                     powers.append(format_stat(power, power_value, default=0, width=self.POWERS_WIDTH))
 
+            # Process sorcery
+            sorcery = character.db.stats.get('powers', {}).get('sorcery', {})
+            if sorcery:
+                powers.append(" " * 38)  # Add spacing
+                powers.append(divider("Sorcery", width=38, color="|b"))
+                for power, values in sorted(sorcery.items()):
+                    power_value = values.get('perm', 0)
+                    powers.append(format_stat(power, power_value, default=0, width=self.POWERS_WIDTH))
+
+            # Process hedge rituals
+            hedge_rituals = character.db.stats.get('powers', {}).get('hedge_ritual', {})
+            if hedge_rituals:
+                powers.append(divider("Hedge Rituals", width=38, color="|b"))
+                for ritual, values in sorted(hedge_rituals.items()):
+                    ritual_value = values.get('perm', 0)
+                    powers.append(format_stat(ritual, ritual_value, default=0, width=self.POWERS_WIDTH))
+
         elif mortalplus_type.lower() == 'faithful':
             # Process faith
             faith = character.db.stats.get('powers', {}).get('faith', {})
@@ -1194,7 +1302,33 @@ class CmdSheet(MuxCommand):
                 for power, values in sorted(faith.items()):
                     power_value = values.get('perm', 0)
                     powers.append(format_stat(power, power_value, default=0, width=self.POWERS_WIDTH))
-        
+                    
+            # Process sorcery
+            sorcery = character.db.stats.get('powers', {}).get('sorcery', {})
+            if sorcery:
+                powers.append(" " * 38)  # Add spacing
+                powers.append(divider("Sorcery", width=38, color="|b"))
+                for power, values in sorted(sorcery.items()):
+                    power_value = values.get('perm', 0)
+                    powers.append(format_stat(power, power_value, default=0, width=self.POWERS_WIDTH))
+
+            # Process numina
+            numina = character.db.stats.get('powers', {}).get('numina', {})
+            if numina:
+                powers.append(" " * 38)  # Add spacing
+                powers.append(divider("Numina", width=38, color="|b"))
+                for power, values in sorted(numina.items()):
+                    power_value = values.get('perm', 0)
+                    powers.append(format_stat(power, power_value, default=0, width=self.POWERS_WIDTH))
+
+            # Process hedge rituals
+            hedge_rituals = character.db.stats.get('powers', {}).get('hedge_ritual', {})
+            if hedge_rituals:
+                powers.append(" " * 38)  # Add spacing
+                powers.append(divider("Hedge Rituals", width=38, color="|b"))
+                for ritual, values in sorted(hedge_rituals.items()):
+                    ritual_value = values.get('perm', 0)
+                    powers.append(format_stat(ritual, ritual_value, default=0, width=self.POWERS_WIDTH))        
         return powers
 
     def process_possessed_powers(self, character, powers):

--- a/commands/CmdShift.py
+++ b/commands/CmdShift.py
@@ -92,6 +92,13 @@ class CmdShift(default_cmds.MuxCommand):
     help_category = "Shifter"
 
     def func(self):
+        # Check if in a Quiet Room
+        if (hasattr(self.caller.location, 'db') and 
+            hasattr(self.caller.location, 'is_command_restricted_in_quiet_room') and
+            self.caller.location.is_command_restricted_in_quiet_room(self.cmdstring)):
+            self.caller.msg("|rYou are in a Quiet Room and cannot use the +shift command here.|n")
+            return
+            
         if "debug" in self.switches:
             # No need to re-import ShapeshifterForm here since it's imported at the top
             all_forms = ShapeshifterForm.objects.all()

--- a/commands/CmdUmbraInteraction.py
+++ b/commands/CmdUmbraInteraction.py
@@ -24,6 +24,13 @@ class CmdUmbraInteraction(MuxCommand):
 
     def func(self):
         """Execute command."""
+        # Check if in a Quiet Room
+        if (hasattr(self.caller.location, 'db') and 
+            hasattr(self.caller.location, 'is_command_restricted_in_quiet_room') and
+            self.caller.location.is_command_restricted_in_quiet_room(self.cmdstring)):
+            self.caller.msg("|rYou are in a Quiet Room and cannot use umbra interaction commands here.|n")
+            return
+            
         if not self.switches:
             if self.cmdstring == "+step":
                 self.do_step()

--- a/data/corax_gifts.json
+++ b/data/corax_gifts.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "Enemy Ways",
-        "description": "The Corax gains an acute and accurate danger sense. This Gift is taught by one of Grandfather Thunder's Stormcrows.",
+        "description": "The Corax gains an acute and accurate danger sense. This Gift is taught by one of Grandfather Thunder’s Stormcrows.",
         "system": "The player rolls Perception + Primal-Urge, difficulty 7. Success grants knowledge of the number and nature of hostile entities within (Wisdom x 20) yards, with more successes granting clearer information.",
         "game_line": "Werewolf: The Apocalypse",
         "source": "Changing Breeds 20th Anniversary Edition",
@@ -30,7 +30,7 @@
     {
         "name": "Raven's Gleaning",
         "description": "The Corax may tell, at a glance, whether or not a shiny object is worth obtaining. A raven-spirit teaches this Gift.",
-        "system": "The player spends a point of Gnosis, bestowing instinctive knowledge of whether or not a specific object the Corax can perceive is of value (this may indicate financial or practical value, or that it will be in some way useful in the future — the Corax doesn't know which).",
+        "system": "The player spends a point of Gnosis, bestowing instinctive knowledge of whether or not a specific object the Corax can perceive is of value (this may indicate financial or practical value, or that it will be in some way useful in the future — the Corax doesn’t know which).",
         "game_line": "Werewolf: The Apocalypse",
         "source": "Changing Breeds 20th Anniversary Edition",
         "category": "powers",
@@ -43,7 +43,7 @@
     },
     {
         "name": "Word Beyond",
-        "description": "This Gift allows the Corax to create a message out of any available materials while in the Umbra, which can be instinctively understood by other wereravens. One of Coyote's brood teaches this Gift.",
+        "description": "This Gift allows the Corax to create a message out of any available materials while in the Umbra, which can be instinctively understood by other wereravens. One of Coyote’s brood teaches this Gift.",
         "system": "The player rolls Wits + Expression (difficulty 6) to create a marker out of nearby Umbral materials. The number of successes indicates the complexity of the message that can be encrypted into the marker; one success would suffice for simple concepts such as “danger” or “safe haven,” while five successes could convey complex concepts equivalent to a short essay. Non-Corax cannot read these markers.",
         "game_line": "Werewolf: The Apocalypse",
         "source": "Changing Breeds 20th Anniversary Edition",
@@ -58,26 +58,13 @@
             "Ratkin"
         ],
         "gift_alias": "Sigil",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Targeted Heave",
-        "description": "A trick swiped from real buzzards, Targeted Heave may well be the most disgusting weapon in the Scabs' arsenal. When cornered or just feeling ornery, a Buzzard can call upon this Gift and heave up the contents of his stomach — digestive juices and all — at a target up to 10 feet away.",
-        "system": "The results of this Gift are very similar to the fomori power: Stomach Pumper. The attack does two dice of damage if it hits (Dexterity + Athletics to hit, difficulty 7), but any victim struck must expend a point of Willpower to keep from stopping whatever they are doing and start gagging.",
-        "game_line": "Werewolf: The Apocalypse",
-        "source": "Buzzard/Wyrm. BotW, p138",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [
-            1
-        ],
-        "shifter_type": "Corax",
+        "auspice": "Knife Skulker",
         "splat": "Shifter"
     },
     {
         "name": "Voice of the Mimic",
         "description": "The Corax may perfectly mimic any voice or sound she has ever heard. A mynah-spirit teaches this Gift.",
-        "system": "This Gift's effects are permanent.",
+        "system": "This Gift’s effects are permanent.",
         "game_line": "Werewolf: The Apocalypse",
         "source": "Changing Breeds 20th Anniversary Edition",
         "category": "powers",
@@ -94,6 +81,10 @@
         "gift_alias": [
             "Mockingbird's Mirror",
             "Serpent's Voice"
+        ],
+        "tribe": "Pumonca",
+        "auspice": [
+            "Kartikeya"
         ],
         "splat": "Shifter"
     },
@@ -127,7 +118,7 @@
     },
     {
         "name": "Razor Feathers",
-        "description": "The Corax's wing-feathers become hard and sharp as steel. This Gift is taught by a steel-spirit, and only functions when the wereraven is in Crinos.",
+        "description": "The Corax’s wing-feathers become hard and sharp as steel. This Gift is taught by a steel-spirit, and only functions when the wereraven is in Crinos.",
         "system": "The player spends a point of Gnosis, enabling Wing Swipe maneuvers for the rest of the scene.",
         "game_line": "Werewolf: The Apocalypse",
         "source": "Changing Breeds 20th Anniversary Edition",
@@ -173,8 +164,8 @@
     },
     {
         "name": "Swallow's Return",
-        "description": "This Gift will safely carry a Corax home, even when she doesn't know where 'home' is. A swallow-spirit teaches it.",
-        "system": "The player spends a point of Gnosis. The Corax flies to the place she truly considers 'home' on autopilot, without any conscious awareness of the path she takes; she may even do so while healing or sleeping.",
+        "description": "This Gift will safely carry a Corax home, even when she doesn’t know where ’home’ is. A swallow-spirit teaches it.",
+        "system": "The player spends a point of Gnosis. The Corax flies to the place she truly considers ’home’ on autopilot, without any conscious awareness of the path she takes; she may even do so while healing or sleeping.",
         "game_line": "Werewolf: The Apocalypse",
         "source": "Changing Breeds 20th Anniversary Edition",
         "category": "powers",
@@ -186,50 +177,8 @@
         "splat": "Shifter"
     },
     {
-        "name": "Shoulder Cracker",
-        "description": "Named after the Chinese method of fortunetelling called scapulimancy, this Gift enables the Tengu to predict the future through reading portents of various kinds. Using this Gift too often, however, leads to misinterpretation and paranoia. A Stormcrow teaches this Gift.",
-        "system": "The Tengu focuses for a minute; the player rolls Wits + Occult to notice and interpret an omen in her surroundings. The omen is usually cryptic.",
-        "game_line": "Werewolf: The Apocalypse",
-        "source": "PGttCB Pg. 198 Tengu",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [
-            2
-        ],
-        "shifter_type": "Corax",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Poisoned Flesh",
-        "description": "By calling upon Poisoned Flesh, a Buzzard can taint the meat of a corpse — anything from a roadkill squirrel to a human body — so that it is poisonous. Even a Corax' legendarily tough digestive tract can't do anything with the garbage this gift leaves behind; it's sheer poison.",
-        "system": "The Buzzard invests a point of Willpower and spits on the target corpse. With a successful Manipulation + Occult roll (difficulty 7), the corpse is poisoned, and it will remain poisoned until the last bits of flesh are flensed away by the elements. Shapeshangers indulging in any portion of a cadaver tainted with this Gift get violently ill for a period of 24 hours unless she succeeds on a Stamina roll (difficulty 9, two successes needed); mortals take three Health Levels of damage. The symptoms include vomiting, dizziness (so flying is out), and occasionally hallucinations. Plus, if she botches the Stamina roll, the unfortunate gourmand smells of the Wyrm for the duration of her sickness.",
-        "game_line": "Werewolf: The Apocalypse",
-        "source": "Buzzard/Wyrm. BotW, p139",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [
-            2
-        ],
-        "shifter_type": "Corax",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Dark Truths",
-        "description": "This Gift allows the Corax to uncover a secret truth or character flaw of an observed subject. As you might expect; Corax love to use this Gift. There's even a game related to Dark Truths that some wereravens play: One Corax uses the Gift on a mortal (in, say, a bar); the other contestants then have to try to wheedle that same secret out of the mark without using Dark Truths. A Fly-spirit teaches this Gift.",
-        "system": "To utilize Dark Truths, the Corax spends a Gnosis point and rolls Perception + Enigmas (difficulty 7). With a success, the Corax acquires knowledge of one of his target's deep dark secrets. While this Gift doesn't turn loose the sort of secrets that are useful in combat, it does pry loose all sorts of interesting blackmail material.",
-        "game_line": "Werewolf: The Apocalypse",
-        "source": "Corax BB p78",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [
-            3
-        ],
-        "shifter_type": "Corax",
-        "splat": "Shifter"
-    },
-    {
         "name": "Dead Talk",
-        "description": "Sometimes a dead man's last vision just isn't enough. This Gift allows the Corax to interrogate a recently-deceased (no more than 24 hours dead) corpse. It is taught by a vulture-spirit.",
+        "description": "Sometimes a dead man’s last vision just isn’t enough. This Gift allows the Corax to interrogate a recently-deceased (no more than 24 hours dead) corpse. It is taught by a vulture-spirit.",
         "system": "The player spends a Gnosis point and rolls Perception + Occult (difficulty 8). The number of successes determines how talkative the corpse is willing to be.",
         "game_line": "Werewolf: The Apocalypse",
         "source": "Changing Breeds 20th Anniversary Edition",
@@ -243,8 +192,8 @@
     },
     {
         "name": "Eyes of the Eagle",
-        "description": "The Corax's keen eyes easily pierce fog, smoke, clouds, darkness — anything short of a solid object. Eagle-spirits teach this Gift.",
-        "system": "The player spends one Gnosis point to enjoy this Gift's benefits for a scene. Adding a Willpower point extends the duration until the sun next rises.",
+        "description": "The Corax’s keen eyes easily pierce fog, smoke, clouds, darkness — anything short of a solid object. Eagle-spirits teach this Gift.",
+        "system": "The player spends one Gnosis point to enjoy this Gift’s benefits for a scene. Adding a Willpower point extends the duration until the sun next rises.",
         "game_line": "Werewolf: The Apocalypse",
         "source": "Changing Breeds 20th Anniversary Edition",
         "category": "powers",
@@ -281,8 +230,7 @@
             3
         ],
         "shifter_type": "Corax",
-        "splat": "Shifter",
-        "gift_alias": "Bloody Feather"
+        "splat": "Shifter"
     },
     {
         "name": "Larder of the Shrike",
@@ -301,7 +249,7 @@
     {
         "name": "Mynah's Touch",
         "description": "The Corax “borrows” knowledge of a single Garou Gift. Mynah-spirits teach this Gift.",
-        "system": "The player spends two Gnosis points, gaining knowledge of any Garou Gift of lower rank than the Corax. The Gift may then be used at any point afterward — once. Mynah's Touch can only 'store' one Gift at a time. In the case of permanent Gifts, the Corax may enjoy the Gift's benefits for one scene before it vanishes.",
+        "system": "The player spends two Gnosis points, gaining knowledge of any Garou Gift of lower rank than the Corax. The Gift may then be used at any point afterward — once. Mynah’s Touch can only ’store’ one Gift at a time. In the case of permanent Gifts, the Corax may enjoy the Gift’s benefits for one scene before it vanishes.",
         "game_line": "Werewolf: The Apocalypse",
         "source": "Changing Breeds 20th Anniversary Edition",
         "category": "powers",
@@ -328,7 +276,7 @@
     },
     {
         "name": "Plague Feather",
-        "description": "Calling upon Plague Feather allows the Buzzard to distill sickness into a single one of his pinfeathers, pluck it, and leave it behind as a trap for the unwary. The first three people to have skin contact with the feather then run the risk of falling terribly ill. Children in particular are vulnerable to Plague Feathers, as they're the most likely to find a big, black shiny feather on the ground an irresistible plaything.",
+        "description": "Calling upon Plague Feather allows the Buzzard to distill sickness into a single one of his pinfeathers, pluck it, and leave it behind as a trap for the unwary. The first three people to have skin contact with the feather then run the risk of falling terribly ill. Children in particular are vulnerable to Plague Feathers, as they’re the most likely to find a big, black shiny feather on the ground an irresistible plaything.",
         "system": "Using Plague Feather involves the expenditure of a point of Gnosis and a point of Willpower, as well as a successful Manipulation + Occult roll (difficulty 8). At that point, the feather is imbued with the power of sickness, and will transfer that contagion to the next three people to touch it. Resisting the disease the feather spreads requires the same roll as does fighting off the effects of Poisoned Flesh.",
         "game_line": "Werewolf: The Apocalypse",
         "source": "BotW p139",
@@ -341,23 +289,9 @@
         "splat": "Shifter"
     },
     {
-        "name": "Yoshitsune's Sword",
-        "description": "The Tengu may use this Gift to increase dramatically a companion's or sentai mate's skill with a melee weapon. An ancestor-spirit teaches this Gift.",
-        "system": "The Tengu touches the target's fighting arm and rolls Wits + Melee (difficulty 5). Success allows the wereraven to spend Gnosis points to increase the target's Melee dice pool by one die per point spent for one scene.",
-        "game_line": "Werewolf: The Apocalypse",
-        "source": "General Hengeyokai CB20 Pg. 284, Tengu",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [
-            3
-        ],
-        "shifter_type": "Corax",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Airt Sense",
+        "name": "Airt Sense Gift",
         "description": "As the spirit Charm. The spirit has a natural sense of the “airts” (directions) of the spirit world, and can travel about without much difficulty. The spirit can create or find spirit tracks at will.",
-        "system": "The Storyteller rolls the spirit's Gnosis if it has to locate a particular place or individual in the Umbra. Even spirits aren't infallible, and a botch can lead them to an unforgiving Realm.",
+        "system": "The Storyteller rolls the spirit’s Gnosis if it has to locate a particular place or individual in the Umbra. Even spirits aren’t infallible, and a botch can lead them to an unforgiving Realm.",
         "game_line": "Werewolf: The Apocalypse",
         "source": "Changing Breeds 20th Anniversary Edition",
         "category": "powers",
@@ -384,8 +318,8 @@
     },
     {
         "name": "Flight of Separation",
-        "description": "When the Corax can't outrun an enemy, confusion is the best stratagem. The Corax explodes into an entire murder of ravens, which take off in all directions — but only one is the true wereraven. An avatar of Raven teaches this Gift.",
-        "system": "The player spends two Gnosis points. Enemies must make a Perception + Enigmas roll (difficulty 3 + wereraven's Honor, maximum 9) to determine which bird is the original. The fake Ravens created by this Gift vanish when the sun next rises; until then, they continue to fly as far and as fast as the Corax could.",
+        "description": "When the Corax can’t outrun an enemy, confusion is the best stratagem. The Corax explodes into an entire murder of ravens, which take off in all directions — but only one is the true wereraven. An avatar of Raven teaches this Gift.",
+        "system": "The player spends two Gnosis points. Enemies must make a Perception + Enigmas roll (difficulty 3 + wereraven’s Honor, maximum 9) to determine which bird is the original. The fake Ravens created by this Gift vanish when the sun next rises; until then, they continue to fly as far and as fast as the Corax could.",
         "game_line": "Werewolf: The Apocalypse",
         "source": "Changing Breeds 20th Anniversary Edition",
         "category": "powers",
@@ -398,7 +332,7 @@
     },
     {
         "name": "Bloody Feather Storm",
-        "description": "Particularly favored by the Tengu of Asia, this Gift causes the wereraven's feathers to rain down on everyone beneath him in a deadly razor-storm. This Gift is taught by a monsoon- or hurricane-spirit.",
+        "description": "Particularly favored by the Tengu of Asia, this Gift causes the wereraven’s feathers to rain down on everyone beneath him in a deadly razor-storm. This Gift is taught by a monsoon- or hurricane-spirit.",
         "system": "The Tengu must be in the air when using this Gift. The player spends three Gnosis and two Rage as his action for the turn. The feather storm causes Dexterity + 4 dice of lethal damage to everything beneath the Tengu within a 15 foot radius. Those caught in the storm must roll three successes on a Dexterity + Athletics roll (difficulty 8) to avoid this damage. If Razor Feathers is active, this damage is aggravated.",
         "game_line": "Werewolf: The Apocalypse",
         "source": "Changing Breeds 20th Anniversary Edition, Tengu",
@@ -482,24 +416,10 @@
     },
     {
         "name": "Theft of Stars",
-        "description": "This Gift renders its target completely unable to see any light derived from a natural source (the sun, moon, or stars, as well as any manner of bioluminescence). Victims are reduced to stumbling about in a bizarre twilight, if not absolute darkness. Helios's avatar teaches this Gift.",
-        "system": "The player spends a point of Willpower and Rage, then makes a contested Willpower roll against the victim. If the Corax wins the roll, her victim is immediately plunged into darkness, capable of seeing only artificial light. The effects of Theft of Stars last for the Corax's Glory in hours.",
+        "description": "This Gift renders its target completely unable to see any light derived from a natural source (the sun, moon, or stars, as well as any manner of bioluminescence). Victims are reduced to stumbling about in a bizarre twilight, if not absolute darkness. Helios’s avatar teaches this Gift.",
+        "system": "The player spends a point of Willpower and Rage, then makes a contested Willpower roll against the victim. If the Corax wins the roll, her victim is immediately plunged into darkness, capable of seeing only artificial light. The effects of Theft of Stars last for the Corax’s Glory in hours.",
         "game_line": "Werewolf: The Apocalypse",
         "source": "Changing Breeds 20th Anniversary Edition",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [
-            5
-        ],
-        "shifter_type": "Corax",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Thieving Talons of the Magpie",
-        "description": "As the Ragabash Gift, which the Corax originally taught to the Garou. The Garou can steal the powers of others and use them herself. These powers can be Garou Gifts, spirit Charms, vampiric Disciplines, True Magic or any other such power. Naturally, a magpie-spirit teaches this Gift.",
-        "system": "The player must gain three successes on a Wits + Stealth roll (difficulty of the target's Willpower). If successful, the Ragabash can use the specified power (and the victim cannot) for each successive turn she is willing to spend a Gnosis point. The werewolf's Gnosis is substituted for any Traits exclusive to the victim that might be necessary to work the power, such as a vampire's blood pool or a mage's Arete. The Ragabash must know something about his target's powers, and he must target a power in the terms by which he would understand it.",
-        "game_line": "Werewolf: The Apocalypse",
-        "source": "Changing Breeds 20th Anniversary Edition, Tengu",
         "category": "powers",
         "stat_type": "gift",
         "values": [

--- a/data/possessed_flaws.json
+++ b/data/possessed_flaws.json
@@ -1,0 +1,42 @@
+[
+	{
+	  "name": "Spirit's Mark (Flaw)",
+	  "description": "The spirit riding you bleeds over into the physical world a bit. You aren’t physically any different (not as a result of this Trait, anyway) but you exude a certain aura. What exactly that aura feels like depends on a) whether Spirit’s Mark is a Merit or a Flaw and b) what kind of spirit possesses you. An attractive fomor might reek of pure lust, granting a -2 on all Seduction-related difficulties. A Kami possesses by a predator-spirit might engender a feeling similar to the Curse in humans (+1 to Social difficulties not related to Intimidation). The Storyteller should work with the player to decide what kind of feeling the character gives off and how it translates into game play. Generally, it should be worth a difficulty adjustment of 1 or 2, depending on how specific the feeling is.",
+	  "system": "",
+	  "game_line": "Werewolf: The Apocalypse",
+	  "category": "flaws",
+	  "stat_type": "",
+	  "values": [2],
+	  "possessed_type": "General"
+	},
+	{
+	  "name": "Known to the Enemy",
+	  "description": "	They've got your number. Someone on the other side knows about you, what you are, and has a general idea of where to find you. If you're a fomor, this might be a Garou or another Gaian shapeshifter. If you're a Kami, this might be a Black Spiral Dancer, perhaps, or a powerful fomor. This Flaw doesn't assume that the enemy is actively hunting you, but if you do anything too conspicuous, they might decide that you're worth the attention.",
+	  "system": "",
+	  "game_line": "Werewolf: The Apocalypse",
+	  "category": "flaws",
+	  "stat_type": "",
+	  "values": [3],
+	  "possessed_type": "General"
+	},
+	{
+	  "name": "Deformity (Possessed)",
+	  "description": "You find it more difficult to hide your Wyrm nature than others. In fact, if you have any unusual markings, such as a tail or body barbs, you cannot hide them. People run in fear from you due to your hideous appearance. This makes it very easy for Garou to distinguish you, and thus you are forced to move more covertly. This is a very common Flaw for fomori. More rare is the Merit: Hidden Power.",
+	  "system": "",
+	  "game_line": "Werewolf: The Apocalypse",
+	  "category": "flaws",
+	  "stat_type": "",
+	  "values": [1],
+	  "possessed_type": "General"
+	},
+	{
+	  "name": "Scary Presence",
+	  "description": "The Wyrm rides you always; no matter how you act or appear, you're cursed to frighten people by your very presence. This Flaw has no physical manifestation — you scare folks simply by existing. Mundane humans will avoid you however they can, and may become violent if pressed. Even other fomori will sense the taint that infects your soul; they may not flee, but you won’t be popular, either. Loneliness is your lot forever.",
+	  "system": "",
+	  "game_line": "Werewolf: The Apocalypse",
+	  "category": "flaws",
+	  "stat_type": "",
+	  "values": [2],
+	  "possessed_type": "Fomori"
+	},
+]

--- a/data/possessed_merits.json
+++ b/data/possessed_merits.json
@@ -1,0 +1,42 @@
+[
+	{
+	  "name": "Spirit's Mark (Merit)",
+	  "description": "The spirit riding you bleeds over into the physical world a bit. You aren’t physically any different (not as a result of this Trait, anyway) but you exude a certain aura. What exactly that aura feels like depends on a) whether Spirit’s Mark is a Merit or a Flaw and b) what kind of spirit possesses you. An attractive fomor might reek of pure lust, granting a -2 on all Seduction-related difficulties. A Kami possesses by a predator-spirit might engender a feeling similar to the Curse in humans (+1 to Social difficulties not related to Intimidation). The Storyteller should work with the player to decide what kind of feeling the character gives off and how it translates into game play. Generally, it should be worth a difficulty adjustment of 1 or 2, depending on how specific the feeling is.",
+	  "system": "",
+	  "game_line": "Werewolf: The Apocalypse",
+	  "category": "flaws",
+	  "stat_type": "",
+	  "values": [2],
+	  "possessed_type": "General"
+	},
+	{
+	  "name": "Banespeak",
+	  "description": "	With your transformation, you have discovered a way into your dark spiritual side and are able to speak with the Bane part of yourself. When you speak with your Bane, you appear to be talking animatedly to yourself. Your Bane whispers dark secrets to the tattered remains of your soul, and your soul withers a little more with each vile revelation. Your Storyteller will create the Bane, but will not reveal to you the extent of its knowledge or its secret powers. While your Bane will not guide you all the time, at moments of deep urgency it may be able to provide you with clues or information about the Wyrm or Garou worlds which you would not otherwise know.",
+	  "system": "",
+	  "game_line": "Werewolf: The Apocalypse",
+	  "category": "merits",
+	  "stat_type": "",
+	  "values": [3],
+	  "possessed_type": "Fomori"
+	},
+	{
+	  "name": "Hidden Power",
+	  "description": "	None of your Powers or Taints are physically obvious. You appear to be human (or whatever you were before becoming a fomor). If you have extra limbs or body barbs, they are retractable and hidden under a sheath of skin. You seem to be one of the crowd.",
+	  "system": "",
+	  "game_line": "Werewolf: The Apocalypse",
+	  "category": "flaws",
+	  "stat_type": "",
+	  "values": [1],
+	  "possessed_type": "Fomori"
+	},
+	{
+	  "name": "Stigmata of the Wyrm",
+	  "description": "	These are marks of the Urge Wyrms which sometimes commune with favored servants. To “win” one, a fomor must first understand the aspects of the Wyrm (which indicates some level of insanity to begin with), then contact her own inner corruption (to discover which aspect favors her), manifest that Urge in word, body and deed, and often undergo some hideous ordeal of consecration. Seeking the Wyrm within often requires a perverted visionquest; this usually involves breaking away from all friends (including other fomori), and indulging in some excess related to the vision your character seeks until some truth appears. These excesses can include killing sprees, near-fatal drug binges, wanton cruelty (brutalizing homeless folks, children, animals, etc.), prolonged depressions, psychotic episodes, mad orgies and other deadly activities. At some point, a vision of the Urge Wyrm’s Malign Incarna appears to the fortunate one and sends her through some excruciating test of loyalty; such ordeals are related to the Urge Wyrm involved — tests of greed, cruelty, deceit, etc. A fomor who survives the test (many do not) receives the mark of favor. Like the tests, stigmata marks relate to the Urge Wyrm the character serves: Pesuak, Lord of Lies, often gifts his chosen with forked tongues. Karnala, Desire’s Urge, has more attractive marks, often hypnotically intriguing tattoos. Foobok gifts his followers with forever-open eyes, while Pizak’s mark consists of massive brands which never heal. The exact nature of the mark is left to the troupe’s imagination, but it should reflect some appropriately deviant behavior. Stigmata can be really useful in social situations with others who understand the mark; Black Spiral Dancers may revere the chosen (or may kill her anyway — they are demented, after all!), and Pentex superiors and Wyrm-mystics will give her respect. Even humans who embrace the Urge Wyrm’s principles will regard the chosen one with a measure of awe and reverence. Stigmata are usually worth one to three extra dice for Social rolls when dealing with the Wyrm-tainted. Naturally, the character will stand out like a beacon to Sense Wyrm and other such Gifts, and must continue to serve the Urge Wyrm whenever possible.",
+	  "system": "",
+	  "game_line": "Werewolf: The Apocalypse",
+	  "category": "flaws",
+	  "stat_type": "",
+	  "values": [4],
+	  "possessed_type": "Fomori"
+	},
+]

--- a/data/rank2_garou_gifts.json
+++ b/data/rank2_garou_gifts.json
@@ -815,16 +815,17 @@
     {
         "name": "Hidden Secrets",
         "description": "Children of Crow are terribly fond of blackmail, and this Gift does a lot to help their natural tendencies along. The Corax know this Gift as Dark Truths; the Shadow Lords learned the Gift from the raven-folk, and improved on it a bit. The Gift is taught by a fly-spirit.",
-        "system": "To use this Gift, the character rolls Perception + Manipulation (difficulty 7). Success indicates the Garou learns one of the target's deepest and most embarrassing secrets. These secrets are of no use in combat, but make excellent blackmail material. Of course, not everyone has secrets of equal value.",
+        "system": "To use this Gift, the character rolls Perception + Manipulation (difficulty 7). Success indicates the Garou learns one of the target's deepest and most embarrassing secrets. These secrets are of no use in combat, but make excellent blackmail material. Of course, not everyone has secrets of equal value.\n\nCorax know this gift as 'Dark Truths.' To utilize Dark Truths, the Corax spends a Gnosis point and rolls Perception + Enigmas (difficulty 7). It functions similarly to Hidden Secrets.",
         "source": "Shadow Lord Tribebook (revised)",
         "game_line": "Werewolf: The Apocalypse",
         "category": "powers",
         "stat_type": "gift",
-        "values": [2],
-		"splat": "Shifter",
+        "values": [2, 3],
+        "splat": "Shifter",
         "tribe": "Shadow Lords",
-        "shifter_type": ["Garou"],
-		"camp": "Children of Crow"
+        "shifter_type": ["Garou", "Corax"],
+        "camp": "Children of Crow",
+        "gift_alias": "Dark Truths"
     },
     {
         "name": "Song of the Earth Mother",

--- a/data/rank3_garou_gifts.json
+++ b/data/rank3_garou_gifts.json
@@ -2071,15 +2071,15 @@
     {
         "name": "Prophetic Vision",
         "description": "This Gift enables the Garou to receive a vision of the future based on the study of the night sky. The vision usually reveals itself in astrological terms (“Lu-Bat's influence suggests an attitude of acceptance towards the events of the next several days” or “The intervention of Shantar indicates that changes may occur rapidly in the near future”). This Gift is taught by a star-spirit.",
-        "system": "The Garou spends one Gnosis point and rolls Wits + Enigmas (difficulty 7). The number of successes indicates how precise a vision appears to the character. A single success provides vague information, while three of more successes allows the revelation of specific details. Storytellers should couch their visions in symbols appropriate to the Incarna and matter at hand; the seer should have to interpret the vision rather than be spoon-fed.",
+        "system": "The Garou spends one Gnosis point and rolls Wits + Enigmas (difficulty 7). The number of successes indicates how precise a vision appears to the character. A single success provides vague information, while three of more successes allows the revelation of specific details. Storytellers should couch their visions in symbols appropriate to the Incarna and matter at hand; the seer should have to interpret the vision rather than be spoon-fed.\n\nGurahl have a version of this Gift as well. They are required to be in a meditative state. The Gurahl rolls Perception + Enigmas (difficulty 9), with the ability to lower the difficulty by spending Gnosis on a rate of 1 Gnosis per -1 difficulty.",
         "source": "Rage Across the Heavens",
         "game_line": "Werewolf: The Apocalypse",
         "category": "powers",
         "stat_type": "gift",
-        "values": [3],
-		"splat": "Shifter",
-		"auspice": "Theurge",
-        "shifter_type": ["Garou"]
+        "values": [3, 5],
+        "splat": "Shifter",
+        "auspice": "Theurge",
+        "shifter_type": ["Garou", "Gurahl"]
     },
     {
         "name": "Umbral Tracking",

--- a/world/wod20th/models.py
+++ b/world/wod20th/models.py
@@ -526,7 +526,7 @@ class MokoleArchidTrait(models.Model):
                 'stat_modifiers': {},
                 'special_rules': 'Bite causes retching, -2 Social'
             },
-            'Tail': {
+            'Tall': {
                 'description': 'Body mass and height doubles, +1 Stamina. Can reach/see over obstacles more easily. +2 to Perception when appropriate.',
                 'can_stack': True,
                 'stat_modifiers': {'stamina': 1},

--- a/world/wod20th/utils/mortalplus_utils.py
+++ b/world/wod20th/utils/mortalplus_utils.py
@@ -99,9 +99,15 @@ def initialize_mortalplus_stats(character, mortalplus_type):
     if 'legacy' not in character.db.stats['identity']:
         character.db.stats['identity']['legacy'] = {}
     
-    # Initialize powers category if it doesn't exist
+    # Initialize common power categories for all Mortal+ types
     if 'powers' not in character.db.stats:
         character.db.stats['powers'] = {}
+    if 'sorcery' not in character.db.stats['powers']:
+        character.db.stats['powers']['sorcery'] = {}
+    if 'numina' not in character.db.stats['powers']:
+        character.db.stats['powers']['numina'] = {}
+    if 'hedge_ritual' not in character.db.stats['powers']:
+        character.db.stats['powers']['hedge_ritual'] = {}
     
     # Initialize pools
     if 'pools' not in character.db.stats:
@@ -114,6 +120,13 @@ def initialize_mortalplus_stats(character, mortalplus_type):
     # Set the type in identity/lineage
     character.set_stat('identity', 'lineage', 'Type', mortalplus_type, temp=False)
     character.set_stat('identity', 'lineage', 'Type', mortalplus_type, temp=True)
+    
+    # Set Banality based on mortalplus_type
+    banality_value = get_default_banality('Mortal+', subtype=mortalplus_type)
+    if banality_value:
+        character.set_stat('pools', 'dual', 'Banality', banality_value, temp=False)
+        character.set_stat('pools', 'dual', 'Banality', banality_value, temp=True)
+        character.msg(f"|gBanality set to {banality_value} for {mortalplus_type}.|n")
     
     # Initialize type-specific stats
     if mortalplus_type == 'Ghoul':
@@ -131,8 +144,6 @@ def initialize_mortalplus_stats(character, mortalplus_type):
         # Set base Glamour and Banality
         character.set_stat('pools', 'dual', 'Glamour', 2, temp=False)
         character.set_stat('pools', 'dual', 'Glamour', 2, temp=True)
-        character.set_stat('pools', 'dual', 'Banality', 3, temp=False)
-        character.set_stat('pools', 'dual', 'Banality', 0, temp=True)
         
         # Initialize House and Legacy fields
         character.set_stat('identity', 'lineage', 'House', '', temp=False)
@@ -145,13 +156,12 @@ def initialize_mortalplus_stats(character, mortalplus_type):
         character.set_stat('identity', 'lineage', 'Affinity Realm', '', temp=True)
         
     elif mortalplus_type == 'Sorcerer':
-        # Initialize sorcery and hedge ritual categories
-        character.db.stats['powers']['sorcery'] = {}
-        character.db.stats['powers']['hedge_ritual'] = {}
+        # Additional sorcerer-specific initializations, if any
+        pass
         
     elif mortalplus_type == 'Psychic':
-        # Initialize numina category
-        character.db.stats['powers']['numina'] = {}
+        # Additional psychic-specific initializations, if any
+        pass
         
     elif mortalplus_type == 'Faithful':
         # Initialize faith category
@@ -168,6 +178,12 @@ def initialize_ghoul_stats(character):
         character.db.stats['powers'] = {}
     if 'discipline' not in character.db.stats['powers']:
         character.db.stats['powers']['discipline'] = {}
+    if 'sorcery' not in character.db.stats['powers']:
+        character.db.stats['powers']['sorcery'] = {}
+    if 'numina' not in character.db.stats['powers']:
+        character.db.stats['powers']['numina'] = {}
+    if 'hedge_ritual' not in character.db.stats['powers']:
+        character.db.stats['powers']['hedge_ritual'] = {}
     
     # Set base Blood Pool and Willpower
     character.set_stat('pools', 'dual', 'Blood', 3, temp=False)
@@ -179,12 +195,21 @@ def initialize_ghoul_stats(character):
 
 def initialize_kinfolk_stats(character):
     """Initialize Kinfolk-specific stats."""
+    # Initialize powers categories if they don't exist
+    if 'powers' not in character.db.stats:
+        character.db.stats['powers'] = {}
+    if 'gift' not in character.db.stats['powers']:
+        character.db.stats['powers']['gift'] = {}
+    if 'sorcery' not in character.db.stats['powers']:
+        character.db.stats['powers']['sorcery'] = {}
+    if 'numina' not in character.db.stats['powers']:
+        character.db.stats['powers']['numina'] = {}
+    if 'hedge_ritual' not in character.db.stats['powers']:
+        character.db.stats['powers']['hedge_ritual'] = {}
+    
     # Set base Willpower
     character.set_stat('pools', 'dual', 'Willpower', 3, temp=False)
     character.set_stat('pools', 'dual', 'Willpower', 3, temp=True)
-    
-    # Initialize Gifts category
-    character.db.stats['powers']['gift'] = {}
     
     # Check for Gnosis Merit
     merits = character.db.stats.get('merits', {}).get('merit', {})
@@ -276,13 +301,19 @@ def initialize_kinain_stats(character):
     character.set_stat('pools', 'dual', 'Willpower', 3, temp=False)
     character.set_stat('pools', 'dual', 'Willpower', 3, temp=True)
     
-    # Initialize Arts and Realms categories (empty until Fae Blood Merit)
+    # Initialize power categories
     if 'powers' not in character.db.stats:
         character.db.stats['powers'] = {}
     if 'art' not in character.db.stats['powers']:
         character.db.stats['powers']['art'] = {}
     if 'realm' not in character.db.stats['powers']:
         character.db.stats['powers']['realm'] = {}
+    if 'sorcery' not in character.db.stats['powers']:
+        character.db.stats['powers']['sorcery'] = {}
+    if 'numina' not in character.db.stats['powers']:
+        character.db.stats['powers']['numina'] = {}
+    if 'hedge_ritual' not in character.db.stats['powers']:
+        character.db.stats['powers']['hedge_ritual'] = {}
     
     # Initialize Affinity Realm in identity/lineage
     if 'identity' not in character.db.stats:
@@ -301,7 +332,9 @@ def initialize_sorcerer_stats(character):
         character.db.stats['powers']['sorcery'] = {}
     if 'hedge_ritual' not in character.db.stats['powers']:
         character.db.stats['powers']['hedge_ritual'] = {}
-    
+    if 'numina' not in character.db.stats['powers']:
+        character.db.stats['powers']['numina'] = {}
+
     # Set base Willpower
     character.set_stat('pools', 'dual', 'Willpower', 5, temp=False)
     character.set_stat('pools', 'dual', 'Willpower', 5, temp=True)
@@ -317,6 +350,10 @@ def initialize_psychic_stats(character):
         character.db.stats['powers'] = {}
     if 'numina' not in character.db.stats['powers']:
         character.db.stats['powers']['numina'] = {}
+    if 'sorcery' not in character.db.stats['powers']:
+        character.db.stats['powers']['sorcery'] = {}
+    if 'hedge_ritual' not in character.db.stats['powers']:
+        character.db.stats['powers']['hedge_ritual'] = {}
     
     # Set base Willpower
     character.set_stat('pools', 'dual', 'Willpower', 5, temp=False)
@@ -329,7 +366,13 @@ def initialize_faithful_stats(character):
         character.db.stats['powers'] = {}
     if 'faith' not in character.db.stats['powers']:
         character.db.stats['powers']['faith'] = {}
-    
+    if 'sorcery' not in character.db.stats['powers']:
+        character.db.stats['powers']['sorcery'] = {}
+    if 'hedge_ritual' not in character.db.stats['powers']:
+        character.db.stats['powers']['hedge_ritual'] = {}
+    if 'numina' not in character.db.stats['powers']:
+        character.db.stats['powers']['numina'] = {}
+
     # Set base Willpower
     character.set_stat('pools', 'dual', 'Willpower', 5, temp=False)
     character.set_stat('pools', 'dual', 'Willpower', 5, temp=True)
@@ -355,6 +398,13 @@ def validate_mortalplus_powers(character, power_type, value):
             if value not in clan_disciplines:
                 return False, f"Ghouls can only learn disciplines from their domitor's clan: {', '.join(clan_disciplines)}"
 
+        if 'sorcery' not in character.db.stats['powers']:
+            character.db.stats['powers']['sorcery'] = {}
+        if 'hedge_ritual' not in character.db.stats['powers']:
+            character.db.stats['powers']['hedge_ritual'] = {}
+        if 'numina' not in character.db.stats['powers']:
+            character.db.stats['powers']['numina'] = {}
+            
     # Validate Kinfolk powers
     elif mortalplus_type == 'Kinfolk':
         if power_type == 'Gifts':
@@ -382,6 +432,13 @@ def validate_mortalplus_powers(character, power_type, value):
             max_gnosis = (gnosis_merit - 4) if gnosis_merit >= 5 else 0
             if int(value) > max_gnosis:
                 return False, f"Character can only have up to {max_gnosis} Gnosis with current Merit level"
+
+        if 'sorcery' not in character.db.stats['powers']:
+            character.db.stats['powers']['sorcery'] = {}
+        if 'hedge_ritual' not in character.db.stats['powers']:
+            character.db.stats['powers']['hedge_ritual'] = {}
+        if 'numina' not in character.db.stats['powers']:
+            character.db.stats['powers']['numina'] = {}
 
     # Validate Kinain powers
     elif mortalplus_type == 'Kinain':

--- a/world/wod20th/utils/shifter_utils.py
+++ b/world/wod20th/utils/shifter_utils.py
@@ -50,7 +50,8 @@ AUSPICE_CHOICES_DICT: Dict[str, List[str]] = {
     'Rokea': ['Brightwater', 'Dimwater', 'Darkwater'],
     'Nagah': ['Kamakshi', 'Kartikeya', 'Kamsa', 'Kali'],
     'Mokole': ['Rising Sun', 'Noonday Sun', 'Shrouded Sun', 'Midnight Sun', 
-               'Decorated Sun', 'Solar Eclipse']
+               'Decorated Sun', 'Solar Eclipse'],
+    'Gurahl': ['Arcas', 'Uzmati', 'Kojubat', 'Kieh', 'Rishi']
 }
 
 ASPECT_CHOICES_DICT: Dict[str, List[str]] = {
@@ -984,6 +985,13 @@ def update_shifter_pools_on_stat_change(character, stat_name, new_value):
     new_value = new_value.lower() if isinstance(new_value, str) else new_value
 
     if stat_name == 'type':
+        # Update Banality based on the new shifter type
+        banality = get_default_banality('Shifter', subtype=new_value)
+        if banality:
+            character.set_stat('pools', 'dual', 'Banality', banality, temp=False)
+            character.set_stat('pools', 'dual', 'Banality', banality, temp=True)
+            character.msg(f"|gBanality set to {banality} for {new_value}.|n")
+            
         # When shifter type is set/changed, call the appropriate initialize function
         initialize_shifter_type(character, new_value)
     elif stat_name == 'breed':

--- a/world/wod20th/utils/stat_mappings.py
+++ b/world/wod20th/utils/stat_mappings.py
@@ -1272,7 +1272,7 @@ def get_identity_stats(splat: str, subtype: str = None, affiliation: str = None)
             elif subtype == 'corax':
                 stats.extend(['Pack', 'Patron Totem'])
             elif subtype == 'gurahl':
-                stats.extend(['Auspice', 'Pack', 'Patron Totem'])
+                stats.extend(['Auspice', 'Tribe', 'Pack', 'Patron Totem'])
             elif subtype == 'kitsune':
                 stats.extend(['Kitsune Path', 'Kitsune Faction', 'Kitsune Clan', 'Go-En', 'Sempai'])
             elif subtype == 'mokole':

--- a/world/wod20th/utils/vampire_utils.py
+++ b/world/wod20th/utils/vampire_utils.py
@@ -313,6 +313,25 @@ def update_vampire_pools_on_stat_change(character, stat_name: str, new_value: st
             character.msg("|rError updating blood pool - invalid generation value.|n")
             return
     
+    # Update Banality when clan changes
+    elif stat_name == 'clan':
+        # Convert clan to proper case using CLAN_CHOICES
+        clan_key = new_value.lower() if new_value else None
+        proper_clan = next((t[1] for t in CLAN_CHOICES if t[0] == clan_key), None)
+        
+        if proper_clan:
+            banality = get_default_banality('Vampire', subtype=proper_clan)
+            if banality:
+                character.set_stat('pools', 'dual', 'Banality', banality, temp=False)
+                character.set_stat('pools', 'dual', 'Banality', banality, temp=True)
+                character.msg(f"|gBanality set to {banality} for {proper_clan}.|n")
+        else:
+            # Set default vampire banality
+            banality = get_default_banality('Vampire')
+            character.set_stat('pools', 'dual', 'Banality', banality, temp=False)
+            character.set_stat('pools', 'dual', 'Banality', banality, temp=True)
+            character.msg(f"|gDefault vampire Banality set to {banality}.|n")
+    
     # Update virtues when path changes
     elif stat_name == 'path of enlightenment':
         if new_value in PATH_VIRTUES:


### PR DESCRIPTION
This update includes the following changes and bug fixes:
* Gurahl are now able to select Auspices in chargen.
* Previously Tribe did not show up on the Gurahl character sheet; this has been fixed.
* +boost has been updated to accomodate the Gurahl specific Rage boost commands, allowing Gurahl to boost their Strength, Stamina, and Health Levels via spending Rage.
* There was a typo in the WoD20th models.py file in the Archid form characteristics ("Tall" was listed as "Tail") which has been resolved.
* An error that prevented Changeling Seeming bonuses from applying and Phyla pools from autogenerating has been resolved.
* Health functions have been updated to map properly to the new tracking system, allowing for more modular action when characters are able to modify their health levels.
* Banality has been updated to apply properly to the different character types.
* (Possibly) fixed an issue where sorcerers and psychics would lose their sorcery or numina from their character sheet.
* Added in Possessed Merits and Flaws