### PR TITLE
Adding Kumo + Bear Rage

### DIFF
--- a/commands/CmdPump.py
+++ b/commands/CmdPump.py
@@ -927,6 +927,10 @@ class CmdPump(default_cmds.MuxCommand):
             old_bonus = caller.db.bonus_health_from_rage
             caller.db.bonus_health_from_rage += amount
             
+            # Store the current time as timestamp for the health boost
+            import time
+            caller.db.health_boost_timestamp = time.time()
+            
             # Get the current injury level to determine which type of health levels to add
             injury_level = caller.db.injury_level or "Healthy"
             
@@ -1142,6 +1146,10 @@ class CmdPump(default_cmds.MuxCommand):
             # Reset the rage-based health boost
             caller.db.bonus_health_from_rage = 0
             caller.db.rage_health_level_type = None
+            
+            # Clear the timestamp
+            if hasattr(caller.db, 'health_boost_timestamp'):
+                delattr(caller.db, 'health_boost_timestamp')
             
             # Reset the specific level type in health_level_bonuses
             if hasattr(caller.db, 'health_level_bonuses') and level_type in caller.db.health_level_bonuses:

--- a/data/shifter_bio.json
+++ b/data/shifter_bio.json
@@ -113,7 +113,7 @@
         "game_line": "Werewolf: The Apocalypse",
         "category": "identity",
         "stat_type": "lineage",
-        "values": ["Dawn", "Midnight", "Dusk", "Tenere", "Hatar", "Kumoti", "Knife Skulkers", "Shadow Seers", "Tunnel Runners", "Warriors"],
+        "values": ["Dawn", "Midnight", "Dusk", "Tenere", "Hatar", "Kumo", "Kumoti", "Antara", "Kumatai", "Padrone", "Knife Skulkers", "Shadow Seers", "Tunnel Runners", "Warriors"],
         "splat": "Shifter"
     },
     {

--- a/world/wod20th/utils/shifter_utils.py
+++ b/world/wod20th/utils/shifter_utils.py
@@ -56,7 +56,7 @@ AUSPICE_CHOICES_DICT: Dict[str, List[str]] = {
 
 ASPECT_CHOICES_DICT: Dict[str, List[str]] = {
     'Ajaba': ['Dawn', 'Midnight', 'Dusk'],
-    'Ananasi': ['Tenere', 'Hatar', 'Kumoti'],
+    'Ananasi': ['Tenere', 'Hatar', 'Kumo', 'Kumoti', 'Antara', 'Kumatai', 'Padrone'],
     'Ratkin': ['Knife Skulkers', 'Shadow Seers', 'Tunnel Runners', 'Warriors'],
     'Mokole': ['Rising Sun', 'Noonday Sun', 'Shrouded Sun', 'Midnight Sun', 
                'Decorated Sun', 'Solar Eclipse']


### PR DESCRIPTION
Added Kumo to the list of Ananasi aspects. Also added other aspects that won't be allowed for PCs (Padrone, Kumatai, and Antara).

Updated boost to add in a time component to ensure that the health bonus from Gurahl rage is removed.