### PR TITLE
4/24 Update

### DIFF
--- a/data/bastet_gifts.json
+++ b/data/bastet_gifts.json
@@ -72,18 +72,6 @@
         "splat": "Shifter"
     },
     {
-        "name": "Tree Climber",
-        "description": "By extending and sharpening his claws, then invoking this Gift, a Bastet may travel up or down any vertical surface, from tree to concrete.",
-        "system": "Climbing this way requires a Dexterity + Athletics roll. Really hard or slippery surfaces, like ice or steel, are difficulty 8, while easy ones like rock or bark are at difficulty 6. The character traveling this way moves at ten feet a turn or so and may have to make new rolls if the circumstances change (in an avalanche, for example).",
-        "source": "Revised - BB Bastet p.97",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [1],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
         "name": "Cat Claws",
         "description": "By calling on her heritage, a Bastet in Homid or Sokto form can unsheathe her claws and attack as if she were in Crinos.",
         "system": "The player need not spend a Willpower point to enact this particular partial transformation (see W20, p. 286), and the difficulty of the transformation is 6.",
@@ -92,78 +80,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [1],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Sweet Hunter's Smile",
-        "description": "As the homid Gift: Persuasion. This Gift allows a homid to become more persuasive when dealing with others, in such a way that his statements and arguments are imbued with added meaning or credibility. An ancestor-spirit teaches this Gift.",
-        "system": "The player rolls Charisma + Subterfuge. If successful, the Storyteller reduces the difficulties of all Social rolls by one for the remainder of the scene. In addition, any successful Social rolls may have significantly more impact than they would without the Gift. A werewolf could win arguments with hard line opponents, or cause a cold-hearted psychopath to relent (at least for a little while).",
-        "source": "CB20 Pg. 86",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [1],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Urban Hunter",
-        "description": "As the homid Gift: City Running. Called Climb Like an Ape in previous versions. Garou with this Gift find that moving vertically is just as easy as moving horizontally; whether they are walking along a sidewalk, climbing stairs, or scaling the side of a building, their pace doesn't change in the slightest, nor do they tire out more rapidly. This Gift doesn't make it any easier or less dangerous to climb in precarious circumstance — a ten-story fall is still a ten-story fall, and a sheer surface remains sheer — but the Gift does make sure that the character can climb as quickly as he walks.",
-        "system": "The player spends a point of Rage. For the next scene the Garou's movement rate is unchanged whether he is climbing or walking; he moves at Dexterity +5 meters per turn, period. This Gift does not decrease the difficulty for Athletics rolls used to climb, but it does allow the Garou to run, or make an Athletics roll to improve his speed, just as he could while moving across an empty plain. This Gift is taught by a monkey-spirit.",
-        "source": "CB20 Pg. 86",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [1],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Create Element",
-        "description": "As the metis Gift. The metis has the power to create a small amount of one of the four basic elements — fire, air, earth or water. In this way, she can replenish the air supply in an airtight room, make a rock to throw at someone, create a fire without matches or wood, or even fill a bathtub without any faucet or pipes. The metis cannot create specialized forms of any element. Precious metals (especially silver), lethal gases and acid are beyond his reach. This Gift creates only natural air, earth, fire and water. Elementals teach this Gift.",
-        "system": "The werewolf's player spends one Gnosis point and rolls Gnosis. Each success allows the character to create approximately one cubic foot of the desired element, to a maximum weight of 100 lbs, anywhere he can see within 60 feet. The element remains in existence until used up (breathed in the case of air or burned up in the case of fire without any fuel to keep it going). The flames created with this Gift are genuinely hot, but they are no substitute for a flame-thrower. They inflict one health level of damage per success, to a maximum of three health levels of damage.",
-        "source": "CB20 Pg. 87",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [1],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Sense Primal Nature",
-        "description": "As the metis Gift: Sense Wyrm, save that its difficulty is one higher and it can simultaneously sense and discern emanations of the Weaver, Wyrm, and Wyld. The werewolf can sense manifestations of the Wyrm in the nearby area. This Gift involves a mystical sense, not a visual or olfactory image, although werewolves using the Gift sometimes say things like, “This place stinks of the Wyrm” (with a few more colorful adjectives). Garou should remember that the Wyrm's taint can cling to relatively blameless souls. Werewolves may sense an innocent person who happens to work in a Wyrm-controlled factory or who has eated tainted food. This power requires active concentration. Any spirit of Gaia may teach this Gift.",
-        "system": "The player rolls Perception + Occult. The difficulty depends on the concentration and strength of the Wyrm's influence. Sensing a single fomor in the next room would be difficulty 6, while detecting the stench of a Bane that was in the room an hour ago would be difficulty 8. Vampires register as Wyrm-tainted, save those with Humanity Traits of 7 or higher.",
-        "source": "CB20 Pg. 87",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [1],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Shed",
-        "description": "As the metis Gift. The Garou knows the trick of shedding and growing fur at an alarming rate. This Gift makes the Garou especially difficult to grapple successfully; opponents find themselves holding tufts of fur instead of their target. The Garou can also slide through tight spaces using his shedding fur as natural lubrication. A lizard-spirit or snake-spirit teaches this Gift.",
-        "system": "The Garou may use his slick outer coating to avoid being grappled. With a successful Dexterity + Primal-Urge roll (difficulty 7), he can free himself from any successful grappling attack. The fur also reduces by two the werewolf's difficulty whenever he squeezes through tight spaces or slips restraints, such as handcuffs.",
-        "source": "CB20 Pg. 87",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [1],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Heightened Senses",
-        "description": "As the lupus Gift. The werewolf with this Gift tunes in to the world around him, increasing his senses vastly. When in Homid or Glabro form, her senses become as sharp as those of a wolf, allowing him to hear sounds beyond his normal range, granting him superior night vision and making his sense of smell stronger than that of any dog. In wolf forms, his senses become preternaturally potent, allowing him to perform feats that border on precognition. This Gift has drawbacks as well. If a fire alarm were to go off around a Garou using this Gift, it might render him helpless. Cities can barrage the werewolf with a sensory overload. Wolf-spirits teach this gift.",
-        "system": "The player spends a Gnosis point. The effects last for one scene. In Homid or Glabro forms, the werewolf's Perception difficulties decrease by two, and he may roll Perception + Primal-Urge to perform sensory feats impossible for humans (such as tracking by scent). In Crinos, Hispo and Lupus forms, Perception difficulties decrease by three (which is not cumulative with the ordinary Lupus-form Perception bonuses), and the werewolf gains an extra die to Primal-Urge dice pools.",
-        "source": "CB20 Pg. 87",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [1],
+		"breed": "Homid",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -177,18 +94,7 @@
         "stat_type": "gift",
         "values": [1],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Pounce",
-        "description": "As the lupus Gift: Hare's Leap. Lupus Version. Called Leap of the Kangaroo for Bunyip and Hare's Leap for Lupus. By invoking this Gift, the werewolf may leap incredible distances. Hare-, frog- and cat-spirits usually teach this Gift. The lost Bunyip knew this Gift as Leap of the Kangaroo, however marsupial-spirits seem loath to aid werewolves these days. Today, many werewolves call this Gift “Leap of the Kangaroo” in their fallen cousins' honor.",
-        "system": "The player rolls Stamina + Athletics (difficulty 7). If successful, she may double her normal jumping distance.",
-        "source": "CB20 Pg. 87",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [1],
-        "shifter_type": "Bastet",
+		"breed": "Feline",
         "splat": "Shifter"
     },
     {
@@ -200,6 +106,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [1],
+		"breed": "Feline",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -212,6 +119,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [1],
+		"breed": "Feline",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -224,42 +132,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [1],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Treeclimber",
-        "description": "As the Stargazer Gift: Balance. The Stargazer is able to walk across any ledge, rope, etc., no matter how thin or slippery. Wind-spirits teach this Gift.",
-        "system": "No point expenditure or roll is required. Difficulties for climbing decrease by three.",
-        "source": "CB20 Pg. 87",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [1],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Hunter's Mists",
-        "description": "As the Black Fury Gift: Curse of Aeolus. The Fury calls up a thick, eerie fog that obscures vision and unnerves her opponents. The Fury can see through the fog, but all other have trouble navigating by sight. A spirit in service to Aeolus, the fog totem, teaches this Gift.",
-        "system": "The player makes a Gnosis roll. The difficulty varies according to the surrounding terrain and humidity: 4 near the sea, 6 under normal circumstances, 9 in a desert. The Black Fury can see normally, but others caught in this fog halve their Perception scores (with regards to sight only). The fog is quite unnerving, and everyone except the Fury and her packmates loses a die from all Willpower dice pools.",
-        "source": "CB20 Pg. 88",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [1],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Storm of Pests",
-        "description": "As the Bone Gnawer Gift: Scent of Sweet Honey. A target the Garou touched at some point during the last hour begins to exude a wonderfully sweet aroma, and becomes slightly sticky to the touch. All manner of vermin quickly appear and coat the victim. The resulting coat of gnats, flies, bees and beetles crawls, stings, and generally impairs vision and hearing. Insect-spirits teach this Gift.",
-        "system": "The player spends one Gnosis point and rolls Wits + Subterfuge (difficulty 7). The target suffers a -1 penalty to all actions for one hour per success; the smell will not wash off during this time.",
-        "source": "CB20 Pg. 88",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [1],
+		"tribe": "Bagheera",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -273,6 +146,7 @@
         "stat_type": "gift",
         "values": [1],
         "shifter_type": "Bastet",
+		"tribe": "Bubasti",
         "splat": "Shifter"
     },
     {
@@ -285,18 +159,7 @@
         "stat_type": "gift",
         "values": [1],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Faerie Light",
-        "description": "As the Fianna Gift. The Garou can conjure a small, bobbing sphere of light. The sphere illuminates only a three-foot area, but that is usually enough to provide the necessary light — or to lead foes into ambush. A marsh-spirit or faerie teaches this Gift.",
-        "system": "The player rolls Wits + Enigmas (difficulty 6). The light can appear anywhere within the Garou's line of sight. It can move, bobbing along at 10 feet per turn, if bidden to do so. The light lasts for one turn per success, but the player can spend a point of Gnosis to make it last for the entire scene.",
-        "source": "CB20 Pg. 88",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [1],
-        "shifter_type": "Bastet",
+		"tribe": "Bubasti",
         "splat": "Shifter"
     },
     {
@@ -309,6 +172,7 @@
         "stat_type": "gift",
         "values": [1],
         "shifter_type": "Bastet",
+		"tribe": "Ceilican",
         "splat": "Shifter"
     },
     {
@@ -321,6 +185,7 @@
         "stat_type": "gift",
         "values": [1],
         "shifter_type": "Bastet",
+		"tribe": "Ceilican",
         "splat": "Shifter"
     },
     {
@@ -333,6 +198,7 @@
         "stat_type": "gift",
         "values": [1],
         "shifter_type": "Bastet",
+		"tribe": "Khan",
         "splat": "Shifter"
     },
     {
@@ -345,18 +211,7 @@
         "stat_type": "gift",
         "values": [1],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Mockingbird's Mirror",
-        "description": "As the Corax Gift: Voice of the Mimic. The Corax may perfectly mimic any voice or sound she has ever heard. A mynah-spirit teaches this Gift.",
-        "system": "This Gift's effects are permanent.",
-        "source": "CB20 Pg. 89",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [1],
-        "shifter_type": "Bastet",
+		"tribe": "Khan",
         "splat": "Shifter"
     },
     {
@@ -369,110 +224,15 @@
         "stat_type": "gift",
         "values": [1],
         "shifter_type": "Bastet",
+		"tribe": ["Pumonca", "Qualmi"],
         "splat": "Shifter",
 		"gift_alias": "Breakfast of Stones"
-    },
-    {
-        "name": "Turned Fur",
-        "description": "As the Wendigo Gift: Camouflage, save that the Qualmi must discard any clothing and equipment before activating the Gift. The Wendigo blends in with the surrounding wilderness, which makes him very difficult to see. A deer-spirit teaches this Gift.",
-        "system": "The difficulties to spot the Garou increase by three, provided that he is in the woods. The werewolf invokes the effects at whim.",
-        "source": "CB20 Pg. 89",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [1],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Majesty",
-        "description": "As the Rokea Gift: King Fish. This Gift allows the Dimwater to command the respect of others. A shark-spirit teaches it.",
-        "system": "The Rokea permanently adds one die to Leadership and Intimidation rolls.",
-        "source": "CB20 Pg. 89",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [1],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Submit",
-        "description": "As the Black Fury Gift: Kneel. By pointing a finger or claw at a target, a Fury can force him to his knees. Only the strongest-willed can do anything but strain and swear in response. This Gift is taught by one of Pegasus's brood.",
-        "system": "The Fury rolls Manipulation + Intimidation (difficulty of the subject's Willpower). Her target falls to his knees unless he spends a Gnosis point to resist the Gift's effects (other supernatural beings may spend their own form of mystic energy, such as blood or quintessence, but mortals remain helpless). The target kneels for one turn per success.",
-        "source": "CB20 Pg. 89",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [1],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Blissful Ignorance",
-        "description": "As the Ragabash Gift. The Garou can become completely invisible to all senses, spirits or monitoring devices by remaining still. A chameleon-spirit teaches this Gift.",
-        "system": "The Garou's player rolls Dexterity + Stealth (difficulty 7). Each success subtracts one success from the Perception + Alertness rolls of those looking for the character actively. If no one is doing so, then just one success indicates complete concealment.",
-        "source": "CB20 Pg. 90",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [1],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Speed of Thought",
-        "description": "As the Silent Strider Gift. The Garou doubles her running speed. A roadrunner- or cheetah-spirit teaches this Gift.",
-        "system": "The player spends one Gnosis point. The Gift lasts until the end of the scene.",
-        "source": "CB20 Pg. 90",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [1],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
     },
     {
         "name": "Call Spirits",
         "description": "By speaking the ancient language of The-World-That-Was, a Bastet may communicate with nearby spirits as if they normally speak her language. This Gift weaves between the Gauntlet and the material world, and carries both ways.",
         "system": "The player rolls Gnosis against the local Gauntlet. If she's standing inside the Penumbra already, no roll is necessary. Once she learns this Gift, the werecat understands Spirit-speech for the rest of her life, although some truly alien spirits might be beyond normal comprehension.",
         "source": "Revised - BB Bastet p.96",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Cat Sight",
-        "description": "As the metis Gift: Eyes of the Cat. The Bastet may see clearly in pitch darkness. His eyes glow a lambent green while this power is in effect.",
-        "system": "The character must state when the Gift is in effect, but it requires no roll or expenditure. The character suffers no difficulty or dice-pool penalties from darkness.",
-        "source": "W20 Changing Breeds p. 86",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Eerie Eyes",
-        "description": "As the homid Gift: Staredown. By staring into the eyes of a human or animal, a Bastet can cause the target to flee in terror. This Gift can be used against other shifters, but the target will freeze in place rather than flee.",
-        "system": "The character using this Gift may focus on only one target per turn; the player rolls Charisma + Intimidation (difficulty 5 + the victim's Rank). The victim flees for one turn per success, although he may expend a Willpower point to resist the Gift's effects for a turn. Should the character score five or more successes, the victim flees for the duration of the scene. Other Fera (and most powerful Wyrm-monsters) will not flee, but they cannot attack while the Gift's user continues to stare them down. However, if they are attacked themselves, all bets are off.",
-        "source": "W20 Changing Breeds p. 86",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "First Slash",
-        "description": "As the Ahroun Gift: Spirit of the Fray. This Gift allows the Bastet to attack with lightning speed, striking before any foe.",
-        "system": "Once the character learns this Gift, its effects are permanent. The Bastet may add 10 to all his initiative rolls, which will nearly always ensure that he strikes first. If he chooses, the character may spend a Gnosis point to add another 10 to his initiative roll. Remember, though, that doing so prevents him from spending Rage to gain extra actions; fera can't use Rage and Gnosis in the same turn.",
-        "source": "W20 Changing Breeds p. 86",
         "game_line": "Werewolf: The Apocalypse",
         "category": "powers",
         "stat_type": "gift",
@@ -505,30 +265,6 @@
         "splat": "Shifter"
     },
     {
-        "name": "Pulse of the Prey",
-        "description": "As the Ragabash Gift. (Formerly Sense of the Prey) If he knows anything about his prey, the character can track it down as rapidly as he can travel. This unerring sense of direction operates anywhere, and it is useful for tracking spirits through the Umbra as well as finding beings on Earth.",
-        "system": "No roll is required unless the target is hiding actively (intent alone is not enough), in which case a Perception + Enigmas roll is made against a difficulty of the target's Wits + Stealth. If the target is a spirit, the difficulty is the spirit's Gnosis.",
-        "source": "W20 Changing Breeds p. 86",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Sense Silver",
-        "description": "As the metis Gift. As consummate warriors, Bastet must be prepared for every eventuality — including silver weaponry. This Gift, taught by Lunes, allows the character to detect the presence of silver.",
-        "system": "The player rolls Perception + Primal-Urge (difficulty 7). If successful, she can detect the presence of any nearby silver. Three successes allow him to pinpoint the silver's location.",
-        "source": "W20 Changing Breeds p. 86",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
         "name": "Shriek",
         "description": "With an ear-splitting scream, the Bastet deafens everyone nearby.",
         "system": "The player rolls Stamina + Intimidation (difficulty 7). Everyone within 20 feet is deafened (and at +1 difficulty to all rolls) for one turn per success.",
@@ -553,42 +289,6 @@
         "splat": "Shifter"
     },
     {
-        "name": "Swipe",
-        "description": "As the Ragabash Gift: Taking the Forgotten. The Bastet with this Gift can steal something from a target, and his victim will forget that she ever possessed the stolen item.",
-        "system": "The player must score three successes on a Wits + Stealth roll (difficulty of the victim's Intelligence + Streetwise).",
-        "source": "W20 Changing Breeds p. 86",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Eavesdropper's Ear",
-        "description": "As the Shadow Lord Gift: Whisper Catching. Secrets are an important commodity, and those who strive to keep their secrets may very well be hiding something dangerous. This Gift was developed to root out potential traitors or plotters against the Garou, but has been open to… certain abuses ever since. The Shadow Lord may supernaturally eavesdrop on whispered conversations nearby, giving her an edge over those with something to hide. This Gift is taught by a crow-spirit.",
-        "system": "The player spends a Willpower point. For the duration of the scene, any whisper within earshot is as audible to the Shadow Lord as if the speaker were speaking loudly and clearly. The player may still have to make Perception checks to hear whispers within earshot if obstacles or distance would make even an ordinary conversation difficult to hear. The Murmur Rite blocks this Gift; the Shadow Lords are not willing to violate the privacy of a shadow moot, even for their own personal gain.",
-        "source": "CB20 Pg. 86",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Jam Technology",
-        "description": "As the homid Gift. The werewolf can cause technological devices to cease functioning, albeit temporarily. Even the simplest of shaped objects will refuse to perform its function. A Gremlin — a type of Wyld-spirit that enjoys breaking things — teaches this Gift.",
-        "system": "The player spends one Gnosis point and rolls Manipulation + Crafts. The werewolf may choose the level of complexity she inteds to “jam.” All technological devices (i.e., any devices shaped from fabricated materials like metal or plastic) of that complexity within 50 feet cease functioning for one turn per success. The devices remain unchanged but inert. Knives won't cut, gunpowder won't ignite, gears won't turn and so on. The difficulty of the roll is based on the following chart: Device Difficulty Computer: 4 Phone: 6 Automobile: 8 Gun: 9 Knife: 10",
-        "source": "CB20 Pg. 86",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
         "name": "Blinding Moonbeam Gaze",
         "description": "The werecat shoots bright beams of moonlight from her eyes. These don't inflict damage, but can blind or distract an opponent, and provide illumination as well.",
         "system": "The player rolls Gnosis (difficulty 7), and may turn her 'high beams' on and off at will for the rest of the scene. The moonbeams are roughly equivalent to a high-powered flashlight.",
@@ -597,6 +297,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [2],
+		"breed": "Metis",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -609,18 +310,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [2],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Prehensile Tail",
-        "description": "As the lupus Gift: Monkey Tail. Although the lupus' tail retains the appearance of a regular wolf's tail, it gains far more agility and flexibility. Although incapable of fine manipulation, the tail can grasp objects, wrap around branches or allow the Garou to hang upside down. The tail can also attack from an unexpected direction. A monkey-spirit must be persuaded to teach a Garou this Gift.",
-        "system": "After learning the Gift, the Garou's tail automatically becomes prehensile whenever she likes. In order to manipulate the tail successfully, the player must make a Dexterity + Athletics roll (difficulty 6). The difficulty can increase for very delicate operations. If the Garou's Strength exceeds her Stamina, she can use the tail to hang or swing. When attempting to life objects with her tail, the Garou's Strength rating is halved. If used as an attack, the tail's damage is Strength -1.",
-        "source": "CB20 Pg. 87",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
+		"breed": "Metis",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -634,18 +324,8 @@
         "stat_type": "gift",
         "values": [2],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Lawgiver's Legacy",
-        "description": "As the Philodox Gift: Command the Gathering. The Philodox draws all eyes to herself with a great exclamation, a clap of her hands, the striking of klaive to shield, or some other such gesture. Until she has had her say, none may depart or interrupt her. A lion-spirit teaches this Gift.",
-        "system": "The player spends one Willpower point and rolls Appearance + Leadership (difficulty equals the highest Willpower among those whose attention she seeks to gain). If the roll succeeds, all in attendance fall quiet and listen. Any individual who wishes to interrupt the Philodox or walk out before she has finished speaking must spend two points of Willpower to do so.",
-        "source": "CB20 Pg. 87",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
+		"breed": "Feline",
+		"tribe": "Balam",
         "splat": "Shifter"
     },
     {
@@ -658,66 +338,7 @@
         "stat_type": "gift",
         "values": [2],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Pathfinder",
-        "description": "As the Ragabash Gift. The werewolf can strike implausible trails through pristine wilderness and the urban jungle alike, locating the fastest and shortest routes from one place to another. A crow-spirit teaches this Gift.",
-        "system": "The player rolls Perception + Survival (for wilderness) or Streetwise (for urban environments) against difficulty 7. The number of successes equals the quality of the path she blazes and how much she decreases her travel time. Every success reduces travel time by approximately 10 percent, up to a maximum of half the original travel time. The difficulty of any rolls to track the werewolf increase by two when this Gift is active; this decrease is cumulative with other similar effects, such as Scent of Running Water.",
-        "source": "CB20 Pg. 88",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Terrors",
-        "description": "As the Ahroun Gift: True Fear. The Ahroun can display the true extent of her power, scaring one chosen foe into quiescence for a number of turns. Spirits of fear teach this Gift.",
-        "system": "The player rolls Strength + Intimidation (difficulty of the target's Willpower). Each success she achieves cows the enemy for one turn; the victim cannot attack at this time. He may defend himself if attacked and otherwise act normally, although his action will likely be guided by fear.",
-        "source": "CB20 Pg. 88",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Smoking Mirror",
-        "description": "As the Rank Three common Bastet Gift: Farsight. As the Uktena Gift: Scrying. By staring into a mirror or other reflective surface, the Bastet can witness distant events or spy on rivals. She can follow a comrade's progress into a dangerous ambush or sneak a peek into the Tremere chantry house. Other supernaturals, especially ones with similar abilities, may have defenses against this Gift.",
-        "system": "After spending one Gnosis point, the player must roll Perception + Occult (difficulty 7). The difficulty increases to 10 if the character does not posses an item owned by the target or something taken from the chosen area. The Bastet can see everything as if she were the proverbial fly on the wall.",
-        "source": "PGttCB p70, Bastet BB p98",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Dreamspeak",
-        "description": "As the Galliard Gift. The Galliard can enter another's dream and thereby affect the course of that dream. The werewolf does not have to be anywhere near the target, but she must know or have seen the dreamer. A Chimerling teaches this Gift.",
-        "system": "The player rolls Wits + Empathy (difficulty 8). If the dreamer awakens while the Galliard is still within the dream, the werewolf is thrown out of the dream world, and he loses a Gnosis point.",
-        "source": "CB20 Pg. 88",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Spirit Barrier",
-        "description": "As the homid Gift: Spirit Ward. A werewolf with this Gift may protect himself from spirits by performing a quick warding rite. To use this Gift, the werewolf draws an invisible pictogram in the air that scares and unnerves any nearby spirits (except pack totems or caern spirits). The symbol travels with the werewolf as long as it lasts. An ancestor-spirit teaches this Gift.",
-        "system": "The player spends one Gnosis point and rolls Manipulation + Rituals (difficulty 7). Spirits within 100 feet of the character (again, except the pack totem or local caern spirits) must subtract one from their dice pools for each success. This Gift lasts for one scene.",
-        "source": "CB20 Pg. 88",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
+		"tribe": "Bagheera",
         "splat": "Shifter"
     },
     {
@@ -730,18 +351,7 @@
         "stat_type": "gift",
         "values": [2],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Banish Burning",
-        "description": "As the homid Gift: Master of Fire. Once humans tamed fire to keep them warm and to drive off the wild beasts, they were humanity's ancient pact with the spirits of fire. The spirits of flame agree to hold back their hunger when the werewolf touches them. An ancestor spirit or a fire-spirit grants this Gift.",
-        "system": "This Gift allows a werewolf to heal fire damage as if it were bashing. This requires the expenditure of a Gnosis point; the effects last for a scene.",
-        "source": "CB20 Pg. 88",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
+		"tribe": "Bubasti",
         "splat": "Shifter"
     },
     {
@@ -754,18 +364,7 @@
         "stat_type": "gift",
         "values": [2],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Heart of Fury",
-        "description": "As the Ahroun Gift. The Garou can steel himself against anger, suppressing his Rage and creating a mental dam against the explosive frenzies of his kind. This anger will catch up with him eventually, though, so he must vent it before it breaks free. A boar-spirit teaches this Gift.",
-        "system": "The player rolls Willpower (difficulty of the character's permanent Rage rating). Every two successes add one to the character's frenzy difficulties for the scene, making it harder to frenzy. When the scene ends, however, past slights and injuries come rushing back to haunt the Garou, refilling the Garou's heart and soul. He must spend one Willpower point or make a frenzy check immediately at the regular difficulty.",
-        "source": "CB20 Pg. 89",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
+		"tribe": "Ceilican",
         "splat": "Shifter"
     },
     {
@@ -778,42 +377,7 @@
         "stat_type": "gift",
         "values": [2],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Snarl of the Predator",
-        "description": "As the Garou Get of Fenris Gift. The Garou lets out a feral snarl that terrifies opponents and cows them into submission. A wolf-spirit teaches this Gift.",
-        "system": "The player rolls Charisma + Intimidation (difficulty of the opponent's Wits + 3). Each success subtracts one die from an opponent's dice pools on the next turn. This Gift takes one full turn to invoke.",
-        "source": "PGttCB p72",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Speak With Wind Spirits",
-        "description": "As the Wendigo Gift. The Wendigo may call upon wind-spirits for knowledge and guidance. He can ask them one question, which must concern the immediate area (wind-spirits have notoriously short attention spans). A wind-spirit teaches this Gift.",
-        "system": "Upon learning this Gift, the Garou can speak with wind-spirits automatically while he is in the Umbra. To ask a question in the Physical world, the player must spend one Gnosis point and roll Manipulation + Expression (difficulty 7). The number of successes reflects the accuracy of the information.",
-        "source": "CB20 Pg. 89",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Spirit of the Fish",
-        "description": "As the Uktena Gift. The werewolf blessed with this Gift can breathe underwater and swim as fast as he can run in Hispo form. Unsurprisingly, a fish-spirit teaches this Gift.",
-        "system": "The player spends one Gnosis and rolls Stamina + Animal Ken (difficulty 7). The effects last for one hour per success.",
-        "source": "CB20 Pg. 89",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
+		"tribe": "Khan",
         "splat": "Shifter"
     },
     {
@@ -826,18 +390,7 @@
         "stat_type": "gift",
         "values": [2],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Stonework",
-        "description": "As the Rank Three Homid Gift: Craft of the Maker, (As the Garou Homid Gift: Reshape Object), except that it only affects stone, dirt, clay and glass, employs a Manipulation + Survival roll, and reshapes the object permanently. The werewolf can shape once-living material (but not undead!) into a variety of objects instantly. Trees may become shelter, buck antlers become spears, animal hides become armor, and flowers become perfumes. The item will resemble the object from which it was shaped (e.g., the aforementioned spear is made of antler, not wood). A Pattern Spider — one of the Weaver's spirits — teaches this Gift.",
-        "system": "The player rolls Manipulation + Crafts against a variable difficulty (5 to turn a broken tree limb into a spear, 8 to turn a plant into a floatable raft) and spends a Gnosis point. The created object will last a length of time according to a specific chart. Expending an additional Gnosis point allows a created weapon to inflict aggravated damage for the scene's duration or until the object returns to its original form. This effect can be made permanent with the sacrifice of a permanent point of Gnosis if the object itself is changed permanently. Successes - Duration / One - 5 minutes Two - 10 minutes Three - One scene Four - One story Five - Permanent.",
-        "source": "Bastet BB p113",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
+		"tribe": "Pumonca",
         "splat": "Shifter"
     },
     {
@@ -850,6 +403,7 @@
         "stat_type": "gift",
         "values": [2],
         "shifter_type": "Bastet",
+		"tribe": "Qualmi",
         "splat": "Shifter"
     },
     {
@@ -862,30 +416,7 @@
         "stat_type": "gift",
         "values": [2],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Armor of Kings",
-        "description": "As the Children of Gaia Gift: Luna's Armor. The Child of Gaia may call for Luna's protection in battle. This Gift even allows limited resistance to silver. A Lune teaches this Gift.",
-        "system": "The Garou concentrates for one full turn, and the player spends a Gnosis point and rolls base Stamina + Survival (difficulty 7). The player may add one die per success to the Garou's soak pool for the rest of the scene. These bonus dice may also be used to soak silver damage, but only these dice. For example, if the Garou's Stamina is 4 and the player rolls three successes, the Garou has seven dice to soak non-silver damage and three to soak silver.",
-        "source": "CB20 Pg. 90",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Heart of Storms",
-        "description": "As the Get of Fenris Gift: Might of Thor. The Garou can increase his strength tremendously, the better to slay his foes. A wolf-spirit teaches this Gift.",
-        "system": "The player spends one Gnosis and one Rage, then rolls Willpower (difficulty 8). The Garou's Strength doubles for one turn per success. After the Gift wears off, the Get is weakened considerably (Physical Attributes are considered 1 and Willpower is halved) until he can rest for at least one hour.",
-        "source": "CB20 Pg. 90",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
+		"tribe": "Qualmi",
         "splat": "Shifter"
     },
     {
@@ -898,6 +429,7 @@
         "stat_type": "gift",
         "values": [2],
         "shifter_type": "Bastet",
+		"tribe": "Simba",
         "splat": "Shifter"
     },
     {
@@ -910,30 +442,7 @@
         "stat_type": "gift",
         "values": [2],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Sense the Unnatural",
-        "description": "As the lupus Gift. The werewolf can sense any unnatural presence and determine its approximate strength and type. Supernatural presences can include magic, spirits, the Wyrm, wraiths and vampires, although it won't pick them out specifically as such. The werewolf may sense a person plagued by hauntings as easily as a ghost. Any spirit servant of Gaia can teach this gift.",
-        "system": "The player rolls Perception + Enigmas. The more successes he rolls, the more information he gains. The sensory input is somewhat vague and subject to interpretation though. For instance, a vampire might smell of old blood, of fear, of rotten flesh, of fresh meat or of whatever else the Storyteller finds appropriate. Interpreting the information properly might require an Intelligence + Occult roll (Storyteller's option).",
-        "source": "CB20 Pg. 90",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Walking Between Worlds",
-        "description": "As the Level Four general Bastet Gift. Swara alone may buy this as a Level Two Gift. This is one of their most closely-guarded secrets. The Bastet may step sideways as Garou do.",
-        "system": "This Gift's effects are permanent once learned.",
-        "source": "CB20 Pg. 90",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [2, 4],
-        "shifter_type": "Bastet",
+		"tribe": "Simba",
         "splat": "Shifter"
     },
     {
@@ -946,6 +455,7 @@
         "stat_type": "gift",
         "values": [2],
         "shifter_type": "Bastet",
+		"tribe": "Swara",
         "splat": "Shifter"
     },
     {
@@ -987,13 +497,15 @@
     {
         "name": "Cheshire Prank",
         "description": "Why should Lewis Carroll have all the fun? It took a while, but enterprising Bastet finally discovered the secret to disappearing from plain sight. Today, it remains a valuable but popular trick.",
-        "system": "By putting on a wide grin, spending a Gnosis point, and rolling Charisma + Subterfuge (difficulty 7), a Bastet may fade from view. The Prank takes three turns to complete. This invisibility lasts for the scene's duration and foils even magical perceptions. The Gift wont dampen sounds, but any werecat who cant move silently by this Rank is in big trouble, anyway. This Gift only works in Feline and Chatro forms, and changing forms ends the invisibility.",
+        "system": "By putting on a wide grin, spending a Gnosis point, and rolling Charisma + Subterfuge (difficulty 7), a Bastet may fade from view. The Prank takes three turns to complete. This invisibility lasts for the scene's duration and foils even magical perceptions. The Gift wont dampen sounds, but any werecat who cant move silently by this Rank is in big trouble, anyway. This Gift only works in Feline and Chatro forms, and changing forms ends the invisibility. (Bastet Qualmi Rank 3 Gift Nighttime Web: As the common Bastet Gift: Cheshire Prank, except that it works in all forms, and does not require a grin.)",
         "source": "Revised - BB Bastet p.98",
         "game_line": "Werewolf: The Apocalypse",
         "category": "powers",
         "stat_type": "gift",
         "values": [3],
         "shifter_type": "Bastet",
+		"gift_alias": "Nighttime Web",
+		"tribe": "Qualmi",
         "splat": "Shifter"
     },
     {
@@ -1001,18 +513,6 @@
         "description": "By chittering slightly, a Bastet may, with this Gift, make her prey come to her. So long as she stands still and chants, the victim will wander slightly dazed until he's close enough to grab. Once the cat moves, the trance is broke. Naturally, this Gift can be used for all kinds of hunting...",
         "system": "The Bastet player rolls Manipulation + Primal Urge (difficulty 7) to command her target to approach. Unless he can resist with a Willpower roll (difficulty 8), any human or animal will obey. Supernatural opponents with a mind empowering supernatural ability (if active when the Gift's influence began) or more than five points of Rage resist at difficulty 6. Otherwise, they're attracted as usual. This only works against victims who were unaware of the Bastet's presence beforehand - as far as they know, they want to wander over that way. Once the prey is close, the werecat can move in however she prefers; a leap, a distraction, or an opening line all work equally well once the target's in place. This Gift does not work in combat.",
         "source": "Revised - BB Bastet p.98",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Farsight",
-        "description": "As the Uktena Gift: Scrying. By staring into a mirror or other reflective surface, the Bastet can witness distant events or spy on rivals. She can follow a comrade's progress into a dangerous ambush or sneak a peek into the Tremere chantry house. Other supernaturals, especially ones with similar abilities, may have defenses against this Gift.",
-        "system": "After spending one Gnosis point, the player must roll Perception + Occult (difficulty 7). The difficulty increases to 10 if the character does not posses an item owned by the target or something taken from the chosen area. The Bastet can see everything as if she were the proverbial fly on the wall.",
-        "source": "W20 Changing Breeds p. 86",
         "game_line": "Werewolf: The Apocalypse",
         "category": "powers",
         "stat_type": "gift",
@@ -1069,18 +569,6 @@
         "splat": "Shifter"
     },
     {
-        "name": "Invisibility",
-        "description": "As the Uktena Gift. The Bastet can vanish from sight.",
-        "system": "When this Gift is in use, the Bastet must concentrate on staying invisible. He cannot move faster than half normal walking speed, and he cannot draw attention to himself.",
-        "source": "W20 Changing Breeds p. 86",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
         "name": "Purr",
         "description": "The ultimate tool of feline seduction: by softly purring near some person or animal, the Bastet instills her with a desire to cuddle, pet and spoil him. So long as he treats his paramour well, she'll want nothing more than to shower him with affection for days at a time. Purr works in any form.",
         "system": "To set this charm in motion, the Bastet must purr audibly for at least a minute. The player spends a Willpower point and rolls Charisma + Empathy (difficulty of the target's Willpower). This Gift works on anyone, and unless she has some reason to suspect a trick, the subject will believe her affections are genuine (soon, they may be). Violence or unreasonable demands ('Go kill that vampire for me, sweetheart') wreck the charm beyond repair - it'll never work on her again. The infatuation lingers for one day per success; the results may last a lifetime.",
@@ -1105,18 +593,6 @@
         "splat": "Shifter"
     },	
     {
-        "name": "Touch the Mind",
-        "description": "As the metis Gift: Mental Speech. This Gift grants mental communication, even over vast distances. The user must either know the target personally (although he does not have to be friends with that person) or have something that belongs to that them, such as a lock of his hair.",
-        "system": "The player rolls Charisma + Empathy (difficulty 8) and expends a Willpower point; the effects last for a scene. His character may hold a mental conversation with a target at a maximum distance of 10 miles per success. It does not allow mind reading, but the werecat may use social Abilities, such as Intimidation.",
-        "source": "W20 Changing Breeds p. 86",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
         "name": "Babel's Cure",
         "description": "By flexing Rahjah's powers, a Bastet can translate any human language in her vicinity. Invoking the Unmaker will turn everything into gibberish.",
         "system": "To render languages either clear or unintelligible, the player rolls her Manipulation + Linguistics (difficulty 6). this Gift works on spoken words, writing, and even body language. Everyone within 50 feet will understand all communications for the duration. Cahlash's inversion of the Gift scrambles everything the same way. Either version lasts for one turn (or minute) per success, and each can cancel the other out.",
@@ -1125,30 +601,9 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [3],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Cowing the Bullet",
-        "description": "As the homid Gift. The spirits of tools recognize man as their master; as a result, they become reluctant to harm the homid. A Weaver-spirit teaches this Gift.",
-        "system": "The player spends a Gnosis point. For the rest of the scene, the Garou gains two additional soak dice against all crafted weapons not made of silver.",
-        "source": "CB20 Pg. 86",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Craft of the Maker",
-        "description": "As the homid Gift: Reshape Object. The werewolf can shape once-living material (but not undead!) into a variety of objects instantly. Trees may become shelter, buck antlers become spears, animal hides become armor, and flowers become perfumes. The item will resemble the object from which it was shaped (e.g., the aforementioned spear is made of antler, not wood). A Pattern Spider — one of the Weaver's spirits — teaches this Gift.",
-        "system": "The player rolls Manipulation + Crafts against a variable difficulty (5 to turn a broken tree limb into a spear, 8 to turn a plant into a floatable raft) and spends a Gnosis point. The created object will last a length of time according to a specific chart. Expending an additional Gnosis point allows a created weapon to inflict aggravated damage for the scene's duration or until the object returns to its original form. This effect can be made permanent with the sacrifice of a permanent point of Gnosis if the object itself is changed permanently. Successes - Duration / One - 5 minutes Two - 10 minutes Three - One scene Four - One story Five - Permanent.",
-        "source": "CB20 Pg. 86",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
+		"breed": "Homid",
+		"gift_alias": "Traveler's Tongues",
+		"tribe": "Bagheera",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -1161,18 +616,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [3],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Visceral Agony",
-        "description": "As the Black Fury Gift. The werewolf's claws change to barbed, wicked talons dripping with black venom. While wounds caused by these claws cause no extra damage, the pain alone they inflict is crippling. A pain-spirit teaches this Gift.",
-        "system": "The player spends a Rage point before the character attacks. Any wound penalties the target suffers as a result of this attack are doubled (i.e., a foe at Wounded would lose four dice). If the target is in frenzy or otherwise resistant to pain, he still suffers normal wound penalties.",
-        "source": "CB20 Pg. 87",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
+		"breed": "Metis",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -1185,42 +629,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [3],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Chains of Mist",
-        "description": "As the Uktena Gift. Silvery filaments spin out from the Garou's claws, becoming streamers of mist that enwrap and confound nearby spirits, sapping their strength. A fog-spirit teaches this Gift.",
-        "system": "The Uktena concentrates for a turn; and the player spends one Gnosis point and rolls Dexterity + Enigmas (difficulty 7). One spirit of the player's choice within 200 feet (60 m) is affected per success. Spirits struck by this Gift treat their Rage, Gnosis, and Willpower ratings as though they were one lower than they truly are for the purpose of all dice rolls for the",
-        "source": "CB20 Pg. 87",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Underbelly",
-        "description": "As the Shadow Lord Gift: Fatal Flaw. The Shadow Lord can discern a target's weakness, granting an advantage in combat. A Stormcrow teaches this Gift.",
-        "system": "The Shadow Lord must concentrate for one full turn. The player rolls Perception + Empathy (difficulty of the target's Wits + Subterfuge). Success grants the Garou an extra die of damage during combat with that target. Additional successes grant knowledge of further weaknesses (although no further damage bonus is gained). Five successes reveal all of the target's flaws.",
-        "source": "CB20 Pg. 87",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Weak Arm",
-        "description": "As the philodox Gift. Philodox are masters of judgment, and this trait extends even into the field of battle. By watching an opponent's fighting style, the werewolf can evaluate his strengths and weaknesses. Snake- and wind-spirits teach this Gift.",
-        "system": "The player rolls Perception + Brawl (difficulty 8). Each success gives her one bonus die to add to her attack or damage rolls against this opponent. For instance, a Philodox who gets four successes on this roll could add two dice to her attack rolls and two to her damage pool. This Gift can be used against a given foe only once per scene, and the benefits are lost at the end of the scene. The Garou must concentrate for a full turn to use this Gift.",
-        "source": "CB20 Pg. 87",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
+		"breed": "Metis",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -1234,30 +643,7 @@
         "stat_type": "gift",
         "values": [3],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Traveler's Tongues",
-        "description": "As the Bastet Homid Gift: Babel's Cure. By flexing Rahjah's powers, a Bastet can translate any human language in her vicinity. Invoking the Unmaker will turn everything into gibberish.",
-        "system": "To render languages either clear or unintelligible, the player rolls her Manipulation + Linguistics (difficulty 6). this Gift works on spoken words, writing, and even body language. Everyone within 50 feet will understand all communications for the duration. Cahlash's inversion of the Gift scrambles everything the same way. Either version lasts for one turn (or minute) per success, and each can cancel the other out.",
-        "source": "Bastet BB p101",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Ancestral Wings",
-        "description": "As the Black Fury Gift: Wings of Pegasus. The Fury can sprout majestic wings when in Hispo form, allowing her to fly at will. An avatar of Pegasus teaches this Gift.",
-        "system": "The player spends a Gnosis point to produce the wings capable of 50 miles per hour (80 kph) flight, which last until dismissed. Fine flying maneuvers require a Dexterity + Athletics roll at a difficulty determined by the Storyteller.",
-        "source": "CB20 Pg. 88",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
+		"tribe": "Bagheera",
         "splat": "Shifter"
     },
     {
@@ -1270,18 +656,7 @@
         "stat_type": "gift",
         "values": [3],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Wandering Forest",
-        "description": "As the Red Talon Gift: Trackless Waste. Humans have no sense of direction, the Talons assert. With this Gift, the Garou can make certain that they don't. The Talon employing Trackless Waste must have some familiarity with the terrain in question. Upon using the Gift, humans become hopelessly lost. Compasses malfunction, maps are misleading, and landmarks seem to be out of place. A spirit of the wilderness teaches this Gift.",
-        "system": "The player spends one Gnosis point and rolls Intelligence + Primal-Urge. Each success “scrambles” a two-mile radius. This Gift functions on other werewolves, but they can resist with a Perception + Primal-Urge roll, and they must score more successes than the Talon to remain unaffected. This Gift lasts for four hours.",
-        "source": "CB20 Pg. 88",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
+		"tribe": "Balam",
         "splat": "Shifter"
     },
     {
@@ -1294,66 +669,8 @@
         "stat_type": "gift",
         "values": [3],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "The Many Tongues of Ptah",
-        "description": "As the homid Gift: Speech of the World. This Gift allows Gaia's warriors to read and wield the spirit of speech, bypassing the need to learn different languages and dialects. The Garou may speak and understand any human language she encounters, though she speaks with an obvious accent, marking her as an outsider. Speech of the World doesn't convey literacy, nor is it an encyclopedia of cultural information. An ancestor-spirit teaches this Gift.",
-        "system": "The player rolls Intelligence + Academics (difficulty 7). The effect lasts for one scene.",
-        "source": "CB20 Pg. 88",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Faerie Kin",
-        "description": "As the Fianna Gift. The Fianna can call upon ancient pacts between her people and the fae. By emitting a special howl, the Garou can call whatever fae are in the area to help. They will obey the Fianna, but not without question. A dream-spirit teaches this Gift, and the teaching normally involves a quest of some kind.",
-        "system": "The player spends at least one Gnosis point and rolls Manipulation + Occult (difficulty 8). Spending more Gnosis increases the raw power of the faeries who respond, while more successes on the roll means that more faeries answer. Note that this Gift may summon changelings or dream-spirits called chimera, but it will call true fae only in strange Umbral reaches, and even then very rarely. Botching this roll is bad news; the faeries who respond are vicious and malevolent, and they will act to hinder the Garou.",
-        "source": "CB20 Pg. 88",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Phantasm",
-        "description": "As the Fianna Gift. The Garou creates an unmoving illusion that contains visual, auditory, olfactory and even tactile elements. A grain-spirit — the so-called “spirit of spirits” — teaches this gift.",
-        "system": "The player spends one Gnosis for each 10-foot area to be covered by the illusion and then rolls Intelligence + Expression. Anyone who doubts the illusion must roll Perception + Alertness and exceed the Garou's successes in order to see through it.",
-        "source": "CB20 Pg. 88",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Data Flow",
-        "description": "As the Garou Glass Walkers Gift. The Glass Walkers originally developed this Gift as a “remote control” for new electronic devices. As the computer gained importance, this Gift gained a whole new utility. Glass Walkers now use this ability to take control of the data resources that are so important to the world's economy and to society in general. By focusing her attention on a single computer, a Glass Walker can take control of that machine from across the room. She can order it to erase its memory, alter security clearances, transmit false data or simply print a document. An electrical spirit or the even more complex computer spirits can teach this Gift.",
-        "system": "A successful Wits + Computer roll (difficulty 7) plus the expenditure of one Gnosis point establishes contact with the computer. As long as the Garou keeps her target in her line of sight, she can maintain contact with the machine. While this Gift allows remote access, the Garou must still make all the appropriate roll to manipulate the computer.",
-        "source": "Bastet BB p110",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Asuras' Bane",
-        "description": "As the Bubasti Gift: Banish Cahlash's Brood. The weretiger's fur turns white with use, rather than black. By calling upon the Father of Dark Spirits, a Bubasti may command Wyrmish spirits to depart. Each time the Bubasti does so, his fur grows a deeper shade of black and his actions become more... erratic. Sense Wyrm detects a faint trace of Wyrm-taint on the Bastet for a week afterward.",
-        "system": "The player spend a Willpower point and rolls Manipulation + Enigmas against a difficulty of the higher of the spirit's Rage or Gnosis. Each success removes three points of the spirit's Essence. Botching the roll inflicts an immediate derangement of the Storyteller's choice.",
-        "source": "CB20 Pg. 89",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
+		"gift_alias": "Asuras' Bane",
+		"tribe": ["Bubasti", "Khan"],
         "splat": "Shifter"
     },
     {
@@ -1366,30 +683,7 @@
         "stat_type": "gift",
         "values": [3],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Maker's Charm",
-        "description": "As the Bastet Homid Gift: Craft of the Maker. (As the Garou Homid Gift: Reshape Object.) The werewolf can shape once-living material (but not undead!) into a variety of objects instantly. Trees may become shelter, buck antlers become spears, animal hides become armor, and flowers become perfumes. The item will resemble the object from which it was shaped (e.g., the aforementioned spear is made of antler, not wood). A Pattern Spider — one of the Weaver's spirits — teaches this Gift.",
-        "system": "The player rolls Manipulation + Crafts against a variable difficulty (5 to turn a broken tree limb into a spear, 8 to turn a plant into a floatable raft) and spends a Gnosis point. The created object will last a length of time according to a specific chart. Expending an additional Gnosis point allows a created weapon to inflict aggravated damage for the scene's duration or until the object returns to its original form. This effect can be made permanent with the sacrifice of a permanent point of Gnosis if the object itself is changed permanently. Successes - Duration / One - 5 minutes Two - 10 minutes Three - One scene Four - One story Five - Permanent.",
-        "source": "Bastet BB p101",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Bayou's Embrace",
-        "description": "As the Red Talon Gift: Quicksand. The Garou turns the ground into a sticky morass that catches foes and prevents them from escaping or even walking. An earth elemental teaches this Gift.",
-        "system": "The player spends a Gnosis point and rolls Manipulation + Primal-Urge (difficulty 7). Each success changes the ground into a quicksand-like bog for a 10-foot radius. Anyone trying to move through it (except the Garou) moves at half walking speed, and he may not execute combat maneuvers that require overland movement. Additionally, all other combat maneuvers take a +1 difficulty penalty.",
-        "source": "CB20 Pg. 89",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
+		"tribe": "Khan",
         "splat": "Shifter"
     },
     {
@@ -1401,7 +695,10 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [3],
-        "shifter_type": "Bastet",
+        "shifter_type": ["Bastet", "Mokole"],
+		"gift_alias": "Dragon's Tongue",
+		"auspice": "Rising Sun Striking",
+		"tribe": "Pumonca",
         "splat": "Shifter"
     },
     {
@@ -1414,18 +711,7 @@
         "stat_type": "gift",
         "values": [3],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Song of the Earth Mother",
-        "description": "As the Shadow Lord Gift. A more powerful version of Sense Wyrm, this Gift allows the user to sense the presence of Wyrm activity within a broad area. Essentially, the Garou communes with the earth and listens to what it says. The Gift is taught by an earth-spirit.",
-        "system": "The user spends 10 minutes communing with the earth, during which time she may take no other actions. The player then spends two Gnosis points and rolls Perception + Occult (difficulty 7). Success indicates that the earth tells her about any supernatural presence within an area of 100 yards (91 m) per success. While the Gift doesn't offer specific information about the being or beings detected, it does indicate whether or not the presence is Wyrm-tainted.",
-        "source": "CB20 Pg. 89",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
+		"tribe": "Pumonca",
         "splat": "Shifter"
     },
     {
@@ -1438,42 +724,7 @@
         "stat_type": "gift",
         "values": [3],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Nighttime Web",
-        "description": "As the common Bastet Gift: Cheshire Prank, except that it works in all forms, and does not require a grin. Why should Lewis Carroll have all the fun? It took a while, but enterprising Bastet finally discovered the secret to disappearing from plain sight. Today, it remains a valuable but popular trick.",
-        "system": "By putting on a wide grin, spending a Gnosis point, and rolling Charisma + Subterfuge (difficulty 7), a Bastet may fade from view. The Prank takes three turns to complete. This invisibility lasts for the scene's duration and foils even magical perceptions. The Gift wont dampen sounds, but any werecat who cant move silently by this Rank is in big trouble, anyway. This Gift only works in Feline and Chatro forms, and changing forms ends the invisibility.",
-        "source": "Bastet BB p115",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Coup de Grace",
-        "description": "As the Black Fury Gift. The Garou studies her foe, looking for the best place to strike. In doing so, she sets herself up to land this devastating attack. An owl-spirit teaches this Gift.",
-        "system": "The player spends one Willpower point and rolls Perception + Brawl (difficulty of the target's Stamina + Dodge). If successful, the player doubles her damage dice on the Garou's next successful attack.",
-        "source": "CB20 Pg. 90",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Fireroar",
-        "description": "As the Khan Gift: Dragonroar. Bellowing like a thunderclap, the Khan breathes a ball of fire onto his foes.",
-        "system": "The player spends two Gnosis points. The fireball is aimed with Dexterity + Brawl, and inflicts Ferocity levels of aggravated damage. In subsequent turns the target continues to burn for half the damage suffered the previous turn (round down), until the flames gutter out.",
-        "source": "PGttCB p73, Bastet BB p112",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
+		"tribe": "Qualmi",
         "splat": "Shifter"
     },
     {
@@ -1486,42 +737,7 @@
         "stat_type": "gift",
         "values": [3],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Wrath of Kings",
-        "description": "As the Silver Fang Gift: Wrath of Gaia. The Garou shows himself in full, terrible, glory as Gaia's chosen warrior. His splendor overwhelms minions of the Wyrm, driving them before him in terror unless they can master their instinctive fear of this predator. An avatar of Gaia herself teaches this Gift.",
-        "system": "The player spends a Gnosis point and rolls Charisma + Intimidation. Any minions of the Wyrm who look upon the Garou for the next scene must roll Willpower (difficulty 7) and equal or exceed the player's successes. Otherwise, they flee in terror.",
-        "source": "CB20 Pg. 90",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Messenger's Fortitude",
-        "description": "As the Silent Strider Gift. The Garou can run at full speed for three days without rest, food or water. When the Garou reaches her destination, she has 10 minutes to complete whatever business brought her, then she must sleep for three days. A camel- or wolf-spirit teaches this Gift.",
-        "system": "The player spends one Gnosis point. The Garou may do nothing but run; stopping ends the Gift. For an additional Gnosis point, he may imbue another being with this Gift's benefits.",
-        "source": "CB20 Pg. 90",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Speed Beyond Thought",
-        "description": "As the Silent Strider Gift. The Garou can run at 10 times his normal land speed. The effects last for up to eight hours, during which the Garou can do nothing but concentrate on running. When the Gift's effects end, the Garou must eat immediately or face frenzy from hunger. A cheetah- or air-spirit teaches this Gift.",
-        "system": "The player spends one Gnosis point and rolls Stamina + Athletics (difficulty 7) to activate the Gift.",
-        "source": "CB20 Pg. 90",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [3],
-        "shifter_type": "Bastet",
+		"tribe": "Simba",
         "splat": "Shifter"
     },
     {
@@ -1534,6 +750,7 @@
         "stat_type": "gift",
         "values": [3],
         "shifter_type": "Bastet",
+		"tribe": "Swara",
         "splat": "Shifter"
     },
     {
@@ -1545,6 +762,19 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [3],
+		"tribe": "Swara",
+        "shifter_type": "Bastet",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Attunement",
+        "description": "Bastet who've set up Den-Realms use this secret to view their holdings from where they stand. By going into a light trance, the werecat in question communes with the spirits in her territory and learns what's going on throughout the Den-Realm. Visitors, intruders or crises can be discovered long before they get too close to the cat herself.",
+        "system": "The player spends a Gnosis point and rolls Perception + Survival (difficulty 6). The more successes she wins, the more she learns. On a botch, the spirits lie.",
+        "source": "Revised - BB Bastet p.99",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "values": [4],
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -1597,38 +827,15 @@
         "splat": "Shifter"
     },
     {
-        "name": "Wolf's Terror",
-        "description": "As the Ahroun Gift: Silver Claws. The Bastet can establish her battlefield primacy against other werebeasts by transforming her own claws into silver.",
-        "system": "The player rolls Gnosis (difficulty 7) to activate the Gift. The transformation lasts for the scene or until the Bastet decides to end the Gift. Silver claws still do aggravated damage to all targets, and they are naturally unsoakable to the Garou and most other werebeasts. While the character manifests the claws, she suffers searing agonies. Each turn, she gains an automatic Rage point. Furthermore, all non-combat difficulties increase by one because of the distraction. When her Rage points exceed her Willpower, she must check for frenzy.",
-        "source": "W20 Changing Breeds p. 86",
+        "name": "Walking Between Worlds",
+        "description": "As the Level Four general Bastet Gift. Swara alone may buy this as a Level Two Gift. This is one of their most closely-guarded secrets. The Bastet may step sideways as Garou do.",
+        "system": "This Gift's effects are permanent once learned.",
+        "source": "CB20 Pg. 90",
         "game_line": "Werewolf: The Apocalypse",
         "category": "powers",
         "stat_type": "gift",
-        "values": [4],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Monkey's Uncle",
-        "description": "As the Glass Walker Gift: Doppelganger, although the Bastet can only take the forms of humans, great cats or Bastet. The Garou may take the exact likeness of any other human, wolf or Garou. A chameleon-spirit teaches this Gift.",
-        "system": "The player spends one Gnosis point and rolls Charisma + Performance (difficulty 8). Traits aren't duplicated, but everything else, including voice, posture and scent, is identical. The effects last for one day per success.",
-        "source": "CB20 Pg. 86",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [4],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Tech Speak",
-        "description": "As the Glass Walker Gift. This Gift allows the Glass Walker to contact others through any technological device. The Garou speaks to a Pattern Spider in or near a technological device and tells them the message to be delivered and whom it should be delivered to. The Pattern Spider then finds the receiver and uses any communications technology near them to deliver the message; Telephones yell it out, (without picking up the handset), electronic billboards display it, computer printers print it out as text. If no communications technology is present, any other technology will activate, though no message will be imparted. If no technology whatsoever is present near the receiver, the Gift fails. A Pattern Spider teaches this Gift.",
-        "system": "The player spends a Gnosis point and rolls Charisma + Science. The difficulty is relevant to the distance the message needs to be sent: The next room is difficulty 4, the same building 5, one block away 6, one mile away 7, a time-zone away 8. Beyond that is difficulty 9. The more successes achieved, the longer the message can be. A single success will only allow one word to be sent, five would allow unlimited length.",
-        "source": "CB20 Pg. 86",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [4],
+        "values": [2, 4],
+		"tribe": "Swara",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -1641,42 +848,22 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [4],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-    {
-        "name": "Moon's Gateway",
-        "description": "As the Ragabash Gift: Open Moon Bridge. The Garou has the ability to open a moon bridge, with or without the premission of the totem of that caern. A Lune teaches this Gift.",
-        "system": "The player spends on Gnosis point. See the Rite of the Opened Bridge for more information on opening moon bridges. The maximum distance that can thereby be covered is 1,000 miles.",
-        "source": "CB20 Pg. 87",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [4],
+		"breed": "Homid",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
 	{
         "name": "Redeem the Waste",
         "description": "Part of a Metis' roll is the salvation of despoiled wilderness. To do so, he'll often sniff around, paw at the earth, rub his scent around and urinate in various places, essentially claiming the place as his own. While this isn't a true Rite of Claiming, it resembles it in many ways. By dedicating himself to this land, he can summon forth a healing power to save it from toxins and other desecrations.",
-        "system": "The player rolls Manipulation + Survival (difficulty 7) and spends a Gnosis point. Each success makes one square half-mile of damaged, cursed or barren land fertile again; uprooted trees wont re-plant themselves, but new trees and plants will rapidly grow. This healing is permanent until someone takes the time to despoil the land agai",
+        "system": "The player rolls Manipulation + Survival (difficulty 7) and spends a Gnosis point. Each success makes one square half-mile of damaged, cursed or barren land fertile again; uprooted trees wont re-plant themselves, but new trees and plants will rapidly grow. This healing is permanent until someone takes the time to despoil the land again. (Bastet Simba Gift The Bountiful Dominion: As the Bastet Metis Gift: Redeem the Waste, except that the magic doubles crop growth, and health, purifies water immediately, and costs one Gnosis per success.)",
         "source": "Bastet BB p103",
         "game_line": "Werewolf: The Apocalypse",
         "category": "powers",
         "stat_type": "gift",
-        "values": [4],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "Beast Life",
-        "description": "As the lupus Gift. The werewolf with this Gift can communicate with other wild animals and attract (or even command) them. Domesticated animals will speak with the werewolf, but they have given themselves to the ways of humans and must be persuaded to obey the Garou. Any animal spirit may teach this Gift, although Lion and Bear are most often sought as teachers. Children of Gaia: Children of Gaia who use this Gift never do so if the animals attracted would come to harm, unless the very heart of a caern is threatened.",
-        "system": "The player spends on Gnosis point and rolls Charisma + Animal Ken (difficulty 7). The character gains the ability to communicate with all animals automatically. One success can attract specific types of animals within a 10-mile radius, and those that can reach the werewolf in a reasonable amount of time will do so. Each additional success adds 10 miles (two successes indicate a 20-mile radius). All wild animals become friendly to the character. They follow any reasonable request the character makes, and many unreasonable ones as well. A character who uses this Gift to force an animal to sacrifice itself had best pay homage to its spirit or risk angering Gaia. The effect lasts for one scene, but the time may be extended by spending one Gnosis point per extra scene desired.",
-        "source": "CB20 Pg. 87",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [4],
+        "values": [4, 5],
+		"breed": "Metis",
+		"tribe": ["Simba", "Balam"],
+		"gift_alias": ["The Bountiful Dominion", "Heal the Wounded Land"],
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -1689,6 +876,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [4],
+		"breed": "Feline",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -1701,6 +889,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [4],
+		"breed": "Feline",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -1713,18 +902,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [4],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "Potter's Clay",
-        "description": "As the Rank Three Bastet Homid Gift: Craft of the Maker (As the Garou Homid Gift: Reshape Object. The werewolf can shape once-living material (but not undead!) into a variety of objects instantly. Trees may become shelter, buck antlers become spears, animal hides become armor, and flowers become perfumes. The item will resemble the object from which it was shaped (e.g., the aforementioned spear is made of antler, not wood). A Pattern Spider — one of the Weaver's spirits — teaches this Gift.",
-        "system": "The player rolls Manipulation + Crafts against a variable difficulty (5 to turn a broken tree limb into a spear, 8 to turn a plant into a floatable raft) and spends a Gnosis point. The created object will last a length of time according to a specific chart. Expending an additional Gnosis point allows a created weapon to inflict aggravated damage for the scene's duration or until the object returns to its original form. This effect can be made permanent with the sacrifice of a permanent point of Gnosis if the object itself is changed permanently. Successes - Duration / One - 5 minutes Two - 10 minutes Three - One scene Four - One story Five - Permanent.",
-        "source": "PGttCB p70, Bastet BB p101",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [4],
+		"tribe": "Bagheera",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -1737,6 +915,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [4],
+		"tribe": "Balam",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -1749,30 +928,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [4],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "Arms of Darkness",
-        "description": "As the Uktena Gift: Coils of the Serpent. Using this Gift, an Uktena can call forth dark tentacles of mist or fog that wrap around enemies and hold them in a viselike grip. Each coil is four feet long and possesses the same Physical characteristics as the werewolf who summons the coils. Any snake-spirit can teach this Gift.",
-        "system": "The player rolls Dexterity + Occult, difficulty 7. Each success causes a single coil to come forth from the surrounding air. The coils focus on a single target, unless the player makes attack rolls against multiple targets, with the normal penalties to the rolls for multiple actions. The coils only bind; they can't inflict damage. To break free, the victim must make a Strength roll, difficulty 7. If his successes exceed the number of coils, he's free. If not, he's still a prisoner. The tentacles last until the end of the scene or until the summoner decides to send them away.",
-        "source": "CB20 Pg. 88",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [4],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "Shadowplay",
-        "description": "As the Theurge Gift. Unlike the werewolf Gift, the Bubasti does not have to mimic the shadow's movements; once free, it can go about its business as if it were a perfect duplicate of the Bastet. Also unlike the Garou Gift, some light must be present to cast the shadow in the first place. The Theurge breathes life into her shadow, which can then perform tasks for her. The shadow moves about independently with the same abilities as its creator. The Theurge's emissary can cause lifesaving distractions, pick up remote objects and even fight battles.",
-        "system": "To activate the shadow, the player must roll Dexterity + Enigmas (difficulty 8) and spend one Gnosis point. The Theurge must act out the doings of her shadow by making “shadow puppets” with her hands. No light need be present for the shadow to be active. In all respects besides appearance, the shadow maintains the same Traits and Abilities as the Garou. The werewolf cannot create multiple shadows. The shadow can operate out of sight of the Garou; its range is ten yards per success.",
-        "source": "PGttCB p72, Bastet BB p109",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [4],
+		"tribe": "Balam",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -1785,18 +941,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [4],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "Gift of Dreams",
-        "description": "As the Galliard Gift. The Galliard crafts a dream, then breathes it into a sleeping individual. A Lune teaches this Gift.",
-        "system": "The player rolls Wits + Expression (difficulty 6) to craft the dream; more successes allows for more vivid and impactful dreams. To ensure that an individual experiences this dream, the Galliard must breathe it into the target's mouth while they sleep. The player spends a Gnosis point to complete the Gift. Dreams crafted with this Gift are often unusually vivid and dramatic, often leaving even lifelong skeptics convinced that they hold some deep meaning.",
-        "source": "CB20 Pg. 88",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [4],
+		"tribe": "Bubasti",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -1809,6 +954,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [4],
+		"tribe": "Ceilican",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -1820,20 +966,10 @@
         "game_line": "Werewolf: The Apocalypse",
         "category": "powers",
         "stat_type": "gift",
-        "values": [4],
+        "values": [3, 4],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "Call Elemental",
-        "description": "As the Uktena Gift. The Garou is able to call one of the four classic elementals to his aid (earth, air, fire or water). An elemental teaches this Gift.",
-        "system": "The player spends one Gnosis point and rolls Gnosis (difficulty of the area's Gauntlet). She must then roll Manipulation + Occult (difficulty 7) to make the elemental look favorably upon the Garou. The elemental vanishes at the end of the scene.",
-        "source": "CB20 Pg. 89",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [4],
-        "shifter_type": "Bastet",
+		"gift_alias": "Fireroar",
+		"tribe": ["Simba", "Khan"],
         "splat": "Shifter"
     },
 	{
@@ -1845,6 +981,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [4],
+		"tribe": "Pumonca",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -1857,6 +994,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [4],
+		"tribe": "Pumonca",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -1869,66 +1007,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [4],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "Chill of Early Frost",
-        "description": "As the Wendigo Gift. The werewolf calls down a mystical chill from Great Wendigo himself, freezing the surrounding lands and anyone in it. A spirit servant of Great Wendigo teaches this Gift.",
-        "system": "The player spends one Gnosis point and rolls Intelligence + Occult (difficulty varies: 4 if it is already winter, 6 for spring, 9 for summer). Success drops the temperature to a bit below freezing in a five-mile radius, or even further below zero if it was already winter. All creatures without a natural coat of fur lose two dice from all pools. This Gift wreaks pure havoc in urban environments, as pipes burst and roads freeze. This Gift lasts for one hour per success. [Note: In the Get of Fenris Tribebook, it says members of Ymir's Sweat can learn “Call of the Early Frost (Level Three Wendigo)” as though it was a tribe gift. However, the core book lists Call of the Early Frost as Level Four. Out of five Camps, they're the only one with a rank change for the Gift they have access to, so it may have been be a notation error in the Tribebook.]",
-        "source": "CB20 Pg. 89",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [4],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "Dancing on Air",
-        "description": "As the Bastet Metis Gift: Moon's Gateway, except that the roll is Intelligence + Enigmas. As the Ragabash Gift: Open Moon Bridge. The Garou has the ability to open a moon bridge, with or without the premission of the totem of that caern. A Lune teaches this Gift.",
-        "system": "The player spends on Gnosis point. See the Rite of the Opened Bridge for more information on opening moon bridges. The maximum distance that can thereby be covered is 1,000 miles.",
-        "source": "Bastet BB p115",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [4],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "Still Breeze Blowing",
-        "description": "Like the Lupus Gift: Elemental Gift, this magic allows a Qualmi to conjure a spirit to shift the elements to her advantage. Dwelling in the North as they do, most members of this tribe favor air and ice elemental over fire or earth. The werewolf calls upon the primal force of Gaia Herself, thereby commanding the spirits of the elements to rise up, undulate forward and even engulf foes. This Gift summons an elemental spirit, not merely the raw matter of the elements, but the primal spirits possessing power enough to challenge even something as powerful as a Nexus Crawler. The elementals grant this Gift.",
-        "system": "The player spends one Gnosis point and rolls Charisma + Occult (difficulty 7). If successful, he calls an elemental who grants him the ability to control a large volume of air, earth, water or fire (in any of their forms) that is approximately 20′ by 20′ per success. The effect lasts for one scene or until the elemental leaves or is destroyed.",
-        "source": "Bastet BB p115",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [4],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "King of Beasts",
-        "description": "As the Philodox Gift, save that it affects all animals within 300 feet. The Philodox's authority extends even into the realm of beasts, such that he can command the loyalty of any specific animal. If successful, the animal follows his commands willingly and unconditionally. A lion- or falcon-spirit teaches this Gift.",
-        "system": "The Philodox must choose one target within 100 feet. The player rolls Charisma + Animal Ken against a difficulty based on the werewolf's relationship with the animal. This power works on only one animal at a time, and it does not attract animals to the Garou's vicinity (see the Level Four lupus Gift: Beast Life). Relationship Difficulty: A sibling: 3 Feed and care for: 6 Stranger: 8 Hostile: 10",
-        "source": "CB20 Pg. 90",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [4],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "The Bountiful Dominion",
-        "description": "A ruler must be prepared to provide for his subjects. By laying this Gift upon the land, a Simba can make the local crops grow quickly, the soil turn fertile and the waters run clear. This Gift comes from the land of Manu T'Chaa, who ended a famine with his wisdom and passed the secret to his descendants.",
-        "system": "As the Metis Gift: Redeem the Waste, except that the magic doubles crop growth, and health, purifies water immediately, and costs one Gnosis per success.",
-        "source": "Bastet BB p116",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [4],
+		"tribe": "Pumonca",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -1941,6 +1020,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [4],
+		"tribe": "Swara",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -1953,6 +1033,8 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [4, 5],
+		"breed": "Feline",
+		"tribe": "Swara",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -2017,18 +1099,6 @@
         "splat": "Shifter"
     },
 	{
-        "name": "Madness",
-        "description": "As the metis Gift. The metis struggles his whole life to find a place, a purpose and a sense of stability in his horrifying existence. With this Gift, he can force others to face their inner demons, including insanity and madness. The nature of the derangement varies among individuals, but it will always be severe, making it impossible for the victim to function normally. Lunes, along with spirits of trickery and madness teach this Gift.",
-        "system": "The player spends a Gnosis point and rolls Manipulation + Intimidation (difficulty of the victim's Willpower). The insanity lasts a number of days equal to the successes rolled on the attempt. During this time, the metis can increase or decrease the effects of the madness, granting the victim lucidity and then driving him into psychosis. Even after the Gift has ended, the repercussions from the bout with madness often haunt the target for the rest of his life.",
-        "source": "CB20 Pg. 86",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [5],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
         "name": "Black Friday",
         "description": "This dreaded Gift, the bane of the Information Age, allows a Bastet to crash a computer network in seconds. By communing with net Spiders (see the Gift: What's the Password?) and promising a few favors, a lucky werecat can wreak system havoc without even touching a keyboard. It's rarely done because of its tendency to backfire (wiping out one's own computer files!), but causes untold headaches for the programmers of Pentex.",
         "system": "The player rolls his Manipulation + Enigmas to convince the Spiders to do his dirty work. Obviously, he has to have some way of reaching them first, such as a Gift, a short visit to the Penumbra, or a message typed into the doomed system. Once the deal is set in motion, the Spiders eat the system's data; a skillful data retriever can undo the damage, but it'll take days or weeks to fix. The Gift's difficulty depends on the size and complexity of the system in question. Protected networks add 1 to the amount of successes needed; magical system include Trinary computers or Technomagical networks (see Mage: The Ascension). A botch causes the Spiders to wreck your own data instead. Note that this kind of tampering immediately sets of alarms on guarded systems; a would-be saboteur would be wise to amscray ontopray! Network - Difficulty - Succs Needed / Small office - 6 - 1-2 Large office - 6 - 3-4 Small Corporate - 7 - 4-5 Large corporate - 8 - 4-5 International/Government - 9 - 5-10 Secret Government/Magical - 10 - 5-15.",
@@ -2037,6 +1107,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [5],
+		"breed": "Homid",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -2049,18 +1120,8 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [5],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "Wrath of Nala",
-        "description": "As the Hakken Gift: Divine Wind. The Hakken can call forth a powerful storm in a designated area. The storm uproots trees and overturns cars in its fury. An ancestor-spirit or a servant of Narukami, Lord of Thunder, teaches this Gift.",
-        "system": "The player rolls Stamina + Enigmas (difficulty 7) and spends a minimum of one Rage point. Each success equals a one-mile (1.6 km) radius for the storm. Each Rage point spent adds a success and, therefore, increases the size of the storm, which lasts for no more than one scene.",
-        "source": "CB20 Pg. 87",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [5],
+		"breed": "Homid",
+		"tribe": "Bubasti",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -2073,6 +1134,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [5],
+		"breed": "Metis",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -2085,6 +1147,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [5],
+		"tribe": "Bagheera",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -2097,6 +1160,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [5],
+		"tribe": "Bagheera",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -2109,30 +1173,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [5],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "Heal the Wounded Land",
-        "description": "As the Rank Four Bastet Metis Gift: Redeem the Waste. Part of a Metis' roll is the salvation of despoiled wilderness. To do so, he'll often sniff around, paw at the earth, rub his scent around and urinate in various places, essentially claiming the place as his own. While this isn't a true Rite of Claiming, it resembles it in many ways. By dedicating himself to this land, he can summon forth a healing power to save it from toxins and other desecrations.",
-        "system": "The player rolls Manipulation + Survival (difficulty 7) and spends a Gnosis point. Each success makes one square half-mile of damaged, cursed or barren land fertile again; uprooted trees wont re-plant themselves, but new trees and plants will rapidly grow. This healing is permanent until someone takes the time to despoil the land again.",
-        "source": "PGttCB p70, Bastet BB p103",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [5],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "Shadow Brethren",
-        "description": "As the Shadow Lord Gift: Shadow Pack. The Garou summons up shadowy duplicates of himself to stand by him in battle. These shadow-wolves resemble the Shadow Lord and have some of the same capabilities. A night-spirit teaches this Gift.",
-        "system": "The player rolls Gnosis (difficulty 8) and spends a variable number of Gnosis points. For each point spent, the Garou summons a shadow-duplicate. These duplicates have the same Attributes and Abilities as the Garou, but they may not use Gnosis or Willpower. Each has only one health level (i.e., any attack that is not soaked destroys it). The duplicates fade at the end of the scene.",
-        "source": "CB20 Pg. 88",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [5],
+		"tribe": "Balam",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -2145,18 +1186,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [5],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "The Madness of Crowds",
-        "description": "As the Bone Gnawer Gift: Riot. This Gift summons a horde of malevolent spirits to provoke the inhabitants of a city into violent rioting. The Gift plays on the hatred and fear of the down-and-outs of the city: the homeless, the poor and even stray animals. The Gnawer can direct the riot to a degree, but such things tend to escalate, and the Garou has no power to stop the riot from doing so. A rat-spirit teaches this Gift.",
-        "system": "The player spends one Gnosis point and rolls Wits + Subterfuge (difficulty 8). If successful, the spirits direct their hosts against a target of the Garou's choice. The different hosts, however, will not necessarily work together — they may even begin to fight each other as the mob mentality takes over. The number of successes determines the area affected. Successes - Extent / 1 - Building 2 - Block 3 - Neighborhood 4 - District (the South Side, etc. ) 5 - Entire City.",
-        "source": "CB20 Pg. 88",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [5],
+		"tribe": "Bubasti",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -2169,6 +1199,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [5],
+		"tribe": "Ceilican",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -2181,18 +1212,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [5],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "Call to Battle",
-        "description": "As the Garou Ahroun Gift: Strength of Will. The Ahroun with this Gift could lead his pack to the gates of Hell itself if that were what it took. A wolf-spirit or an Incarna avatar teaches this Gift.",
-        "system": "The Garou's player spends a point of Willpower and rolls Charisma + Leadership (difficulty 8). Each success grants all the Garou's allies within 100 feet an extra point of Willpower. These extra points last for the rest of the scene, and they can be spent as usual. This Gift can even raise an ally's Willpower above its maximum or even above 10. This Gift may be used only once per scene.",
-        "source": "PGttCB p72, Bastet BB p113",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [5],
+		"tribe": "Khan",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -2205,18 +1225,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [5],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "Thunderbird's Cry",
-        "description": "As the Hakken Gift: Divine Wind. The Hakken can call forth a powerful storm in a designated area. The storm uproots trees and overturns cars in its fury. An ancestor-spirit or a servant of Narukami, Lord of Thunder, teaches this Gift.",
-        "system": "The player rolls Stamina + Enigmas (difficulty 7) and spends a minimum of one Rage point. Each success equals a one-mile (1.6 km) radius for the storm. Each Rage point spent adds a success and, therefore, increases the size of the storm, which lasts for no more than one scene.",
-        "source": "CB20 Pg. 89",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [5],
+		"tribe": "Khan",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -2230,6 +1239,7 @@
         "stat_type": "gift",
         "values": [5],
         "shifter_type": "Bastet",
+		"tribe": "Qualmi",
         "splat": "Shifter"
     },
 	{
@@ -2242,30 +1252,7 @@
         "stat_type": "gift",
         "values": [5],
         "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "Obedience",
-        "description": "As the Shadow Lord Gift. With the power of this Gift, the Shadow Lord becomes the ultimate alpha, compelling all others to follow her orders. A Stormcrow teaches this Gift.",
-        "system": "The player spends one Gnosis point and rolls Charisma + Leadership (difficulty 8). All in the vicinity must roll Willpower (difficulty 8) and match or exceed the Garou's successes to avoid the effects of the Gift. If the werewolf wins by one success, the targets follow any order they don't mind following. Getting three successes means that the targets will treat the Garou as their alpha and fight for him. Getting five successes means that the targets will follow him into the Abyss or perform other virtually suicidal actions.",
-        "source": "CB20 Pg. 90",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [5],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "Command the Multitude",
-        "description": "Like the Rank One Gift: Submit, except that it affects everyone in a 200 foot radius and requires a Gnosis point. To make things easy, the Storyteller may simply have the player roll three successes with Willpower (difficulty 9) to dominate a strong-willed crowd. Lesser foes, like normal humans or animals, reduce the difficulty to 6. As the Black Fury Gift: Kneel. By pointing a finger or claw at a target, a Fury can force him to his knees. Only the strongest-willed can do anything but strain and swear in response. This Gift is taught by one of Pegasus's brood.",
-        "system": "The Fury rolls Manipulation + Intimidation (difficulty of the subject's Willpower). Her target falls to his knees unless he spends a Gnosis point to resist the Gift's effects (other supernatural beings may spend their own form of mystic energy, such as blood or quintessence, but mortals remain helpless). The target kneels for one turn per success.",
-        "source": "Bastet BB p116",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [5],
-        "shifter_type": "Bastet",
+		"tribe": "Qualmi",
         "splat": "Shifter"
     },
 	{
@@ -2277,6 +1264,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [5],
+		"tribe": "Simba",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     },
@@ -2289,18 +1277,7 @@
         "category": "powers",
         "stat_type": "gift",
         "values": [5],
-        "shifter_type": "Bastet",
-        "splat": "Shifter"
-    },
-	{
-        "name": "All Beasts Under the Sun",
-        "description": "As the Garou Black Fury Gift: The Thousand Forms. Most trickster archetypes are shapeshifters, and the Ragabash is no different. The Garou with this Gift may change herself into any animal between the sizes of a small bird and a bison. The Garou gains all the special powers (flight, gills, poison, sensory abilities, etc.) of the animal she mimics. She may not take the form of Wyrm-beasts (not that she would wish to!), but she may take the form of mythical beasts with some extra effort. Black Furies: The Fury that chooses to risk taking the form of a mythical beast typically honors Pegasus by assuming her form.",
-        "system": "The player spends a Gnosis point and rolls Intelligence + Animal Ken. The difficulty varies, rising higher the farther removed from the Garou's natural form the desired animal is. For example, an ape or panther (mammals of roughly equal mass) might be difficulty 5, while an alligator (a reptile of slightly larger size) would be difficulty 7, and a frog (a much smaller amphibian) would be difficulty 0. Mimicking mythical animals is always difficulty 10.",
-        "source": "Bastet BB p118",
-        "game_line": "Werewolf: The Apocalypse",
-        "category": "powers",
-        "stat_type": "gift",
-        "values": [5],
+		"tribe": "Simba",
         "shifter_type": "Bastet",
         "splat": "Shifter"
     }

--- a/data/gurahl_gifts.json
+++ b/data/gurahl_gifts.json
@@ -1,10 +1,12 @@
 [
     {
-        "name": "Mask of the Bear Spirit",
-        "description": "The Gurahl can take on certain ursine features while in homid form, becoming more intimidating. An ancestor-spirit teaches this Gift.",
+        "name": "Nature's Plenty",
+        "description": "This Gift allows the Gurahl to always locate sufficient food and medicinal herbs to tend to an individual in need of his ministrations. Regardless of the season, enough of the required plants or herbs may be found, even if they are buried under deep snow or growing in the most unlikely of places. A raven-spirit teaches this Gift.",
+        "system": "The player spends a Gnosis point and rolls Perception + Survival, difficulty 7.",
         "game_line": "Werewolf: The Apocalypse",
         "category": "powers",
         "stat_type": "gift",
+        "source": "CB20 Pg. 115",
         "values": [
             1
         ],
@@ -12,11 +14,132 @@
         "splat": "Shifter"
     },
     {
-        "name": "Beneath the Surface",
-        "description": "The Gurahl can sense the true emotional state of others, piercing through deception and facades. A bear-spirit teaches this Gift.",
+        "name": "Fiddlefish",
+        "description": "By invoking this Gift and scooping her hand (or paw) into a river, stream, or other body of water where fish may be found, a Gurahl can guarantee herself a nutritious dinner. Using this Gift presents the Gurahl with a fish large enough to satisfy her hunter. If a Gurahl overuses this Gift (particularly if she returns to the same spot over and over), Gaia's disapproval the implied greed or laziness manifests in a failure to procure a meal. While two or more Gurahl may each aquire a fish from one spot through using this Gift, an individual Gurahl may not snare more than one fish through the use of Fiddlefish unless she moves at least half a mile up or down stream from the original casting place.",
+        "system": "So long as she attempts to acquire a single fish, a Gurahl does not need to spend Gnosis or make a roll for this Gift to succeed. If the Gurahl wishes for more than one fish and makes the effort to relocate to another spot, the player may roll Dexterity + Athletics to see if Gaia blesses the Gurahl with additional fish. Success means that the Gurahl gains another large, tasty fish. Failure results in no additional fish, while a botch means that Gaia is displeased with the Gurahl, who must then make appropriate restitution before trying to use the Gift again. Until the Gurahl atones for a botched attempt at invoking this Gift, future uses of Fiddlefish fail automatically.",
         "game_line": "Werewolf: The Apocalypse",
         "category": "powers",
         "stat_type": "gift",
+        "source": "Gurahl BB Pg 101",
+        "values": [
+            1
+        ],
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Ursa's Light",
+        "description": "The Gurahl may draw down the light of the stars for illumination or a directional beacon. An ancestor-spirit teaches this Gift.",
+        "system": "The Gurahl reaches toward the sky while the player makes a Charisma + Occult roll (difficulty 6). Success produces a soft light that illuminates a 100' square area, or sends a directional beacon 100 yards. If he can see either of the constellations Ursa Major or Ursa Minor, the double the affected area.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 116",
+        "values": [
+            1
+        ],
+        "breed": "Homid",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Voice of Woe",
+        "description": "The Gurahl sends out a call of distress. A bear-spirit teaches this Gift.",
+        "system": "The player spends a point of Gnosis and rolls Charisma + Primal-Urge (difficulty 6). All Gaian shapeshifters within (successes x 5) miles hear the call and know precisely what sort of creature is in trouble, how far away he is, and what direction to head in to get there.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 116",
+        "values": [
+            1
+        ],
+        "breed": "Ursine",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Walk Like a Man",
+        "description": "The Gurahl may leave human footprints or bear prints behind in any form, at his discretion. A fox-spirit teaches this Gift.",
+        "system": "The player rolls Dexterity + Larceny, difficulty 7. This Gift's effects lasts for one scene.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 116",
+        "values": [
+            1
+        ],
+        "auspice": "Arcas",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Ultimatum",
+        "description": "By pitting his will against his opponent's, the Gurahl may reduce his enemy's choices down to two options. (“Fight me now or flee like a rabbit!”) A rattlesnake-spirit teaches this Gift.",
+        "system": "The player spends a Gnosis point and makes a contested Willpower roll (difficulty 6). Success allows the Gurahl to present an enemy with two choices, and the opponent must follow one or the other. The Gurahl cannot make either of these commands suicidal or directly harmful to the opponent, nor may they both amount to slight rewordings of the same action.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 117",
+        "values": [
+            1
+        ],
+        "auspice": "Uzmati",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Stonesight",
+        "description": "The Gurahl may look through a piece of stone or rock to see its potential or composition. Aside from the obvious benefits for sculptors and builders, the Gift is also useful for uncovering hidden minerals or fossils, as well as identifying stones of mystic significance. An earth elemental teaches this Gift.",
+        "system": "The player rolls Perception + Enigmas (difficulty 5) to learn about the stone. The more successes gained, the more in-depth the knowledge.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 117",
+        "values": [
+            1
+        ],
+        "auspice": "Kojubat",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Diagnose",
+        "description": "The Gurahl can determine anyone's general health with little more than a glance. A bear-spirit teaches this Gift.",
+        "system": "The character can take Medicine actions to diagnose patients in only a single turn of inspection. This Gift's effects are permanent.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 118",
+        "values": [
+            1
+        ],
+        "auspice": "Kieh",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Befriend",
+        "description": "The Gurahl seems as a friend to all she meets. A dog-spirit teaches this Gift.",
+        "system": "The character adds one automatic success to all attempts to make a good first impression. This Gift's effects are permanent.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 118",
+        "values": [
+            1
+        ],
+        "auspice": "Rishi",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Treeshake",
+        "description": "By simply shaking a tree, the Gurahl may procure enough fruits and nuts to feed several people — regardless of what sort of tree is selected, or whether it is in season. A bear-spirit teaches this Gift.",
+        "system": "The player spends one Gnosis point, and produces enough food to sate (Succor) individuals.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 115",
         "values": [
             2
         ],
@@ -24,23 +147,133 @@
         "splat": "Shifter"
     },
     {
-        "name": "Slumber",
-        "description": "The Gurahl can cause others to fall into a deep sleep. A bear-spirit teaches this Gift.",
+        "name": "Climate Control",
+        "description": "The Gurahl can raise or lower the temperature around her. A migratory bird-spirit teaches this Gift.",
+        "system": "The player rolls Manipulation + Primal-Urge, difficulty 6. Each success allows the player to raise or lower the temperature in the area by 5 degrees.",
         "game_line": "Werewolf: The Apocalypse",
         "category": "powers",
         "stat_type": "gift",
+        "source": "CB20 Pg. 116",
         "values": [
             2
         ],
+        "breed": "Homid",
         "shifter_type": "Gurahl",
         "splat": "Shifter"
     },
     {
-        "name": "Curse of the Bear",
-        "description": "The Gurahl can curse enemies with bad luck and misfortune. An ancestor-spirit teaches this Gift.",
+        "name": "Weather Watch",
+        "description": "The Gurahl can accurately predict the weather without any prior knowledge. A bear-spirit teaches this Gift.",
+        "system": "The Gurahl permanently gains five extra dice on Survival rolls to predict the weather.",
         "game_line": "Werewolf: The Apocalypse",
         "category": "powers",
         "stat_type": "gift",
+        "source": "CB20 Pg. 116",
+        "values": [
+            2
+        ],
+        "breed": "Ursine",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Cajole",
+        "description": "The character uses this Gift to coax another individual into giving her something, such as food, an item, or a service. Bear- or dog-spirits teach this Gift.",
+        "system": "The player spends a Gnosis point and rolls Charisma + Empathy against a difficulty of the target's Willpower. The larger the gift or service requested, the more successes needed; five successes will cajole a human into giving up house and home.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB Pg. 117",
+        "values": [
+            2
+        ],
+        "auspice": "Arcas",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Mangi's Strong Arms",
+        "description": "The Gurahl squeezes the life from her opponent with this Gift. A bear-spirit or death-spirit teaches it.",
+        "system": "The Gurahl spends an action in concentration. Then the player spends a Rage point and rolls Strength + Primal-Urge. Each success adds one die to the Gurahl's damage on his next successful grappling attack.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB Pg. 117",
+        "values": [
+            2
+        ],
+        "auspice": "Uzmati",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Threaten",
+        "description": "The Gurahl stands upright and roars, causing her opponents to flee in terror. A bear-spirit teaches this Gift.",
+        "system": "The player spends one Rage point and rolls Charisma + Intimidation (difficulty of the victim's Willpower + 2, maximum 9). Three or more successes cause the victim to flee in terror for (Honor) turns; fewer simply induce fear, producing a –1 penalty to all actions for the same duration.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB Pg. 117",
+        "values": [
+            2
+        ],
+        "auspice": "Uzmati",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Song of Terra",
+        "description": "The Gurahl may touch the earth and hear what occurred in that spot in the recent past. A hare-spirit teaches this Gift.",
+        "system": "The player rolls Perception + Primal-Urge (difficulty 6) and spends a Gnosis point. The Gurahl hears the most significant event to occur on that spot during the last (successes rolled) days.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB Pg. 118",
+        "values": [
+            2
+        ],
+        "auspice": "Kojubat",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Refresh",
+        "description": "The Gurahl's blessing helps a target ignore pain until the end of battle. A bear-spirit teaches this Gift.",
+        "system": "The Gurahl must touch her target. The player spends a Gnosis point; the target suffers no wound penalties until the end of the combat.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB Pg. 118",
+        "values": [
+            2
+        ],
+        "auspice": "Kieh",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Compel Truth",
+        "description": "The Gurahl compels an individual to speak the truth. A falcon-spirit teaches this Gift.",
+        "system": "The player rolls Wits + Empathy (difficulty of the target's Willpower) and spends a point of Gnosis. Each success renders the target incapable of deliberate falsehood for one minute.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB Pg. 118",
+        "values": [
+            2
+        ],
+        "auspice": "Rishi",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Dreams of the Buri-Jaan",
+        "description": "The Gurahl sends dream messages to a known cub she has chosen to mentor. These dreams and visions act as both a summons and a directional guide. An ancestor-spirit teaches this Gift.",
+        "system": "The player spends a Gnosis point and rolls Wits + Occult (difficulty determined by the distance between the two — difficulty 4 if the cub is within a mile, up to difficulty 9 for a cub over a thousand miles away). Alternately, spending two Gnosis points allows the character to send dreams and visions to an unknown cub actively seeking guidance.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 115",
         "values": [
             3
         ],
@@ -48,47 +281,133 @@
         "splat": "Shifter"
     },
     {
-        "name": "Healing Sleep",
-        "description": "The Gurahl can place others in a healing trance that accelerates their natural recovery. A bear-spirit teaches this Gift.",
+        "name": "Sense Need",
+        "description": "The Gurahl can open her senses to discover someone in need or rescue or succor. An ancestor-spirit teaches this Gift.",
+        "system": "The player rolls Perception + Empathy. The number of successes rolled determines how the clarity of the pull she feels toward an individual in need within (Succor) miles, if one exists.",
         "game_line": "Werewolf: The Apocalypse",
         "category": "powers",
         "stat_type": "gift",
+        "source": "CB20 Pg. 116",
         "values": [
             3
         ],
+        "breed": "Homid",
         "shifter_type": "Gurahl",
         "splat": "Shifter"
     },
     {
-        "name": "Rage of the Bear",
-        "description": "The Gurahl channels the legendary fury of the bear, becoming a terrifying force of destruction. A bear-spirit teaches this Gift.",
+        "name": "Pull of the Chosen Land",
+        "description": "The Gurahl can find the shortest, fastest route to his protectorate, regardless of where he is and how he got there.",
+        "system": "The player spends a point of Gnosis and rolls Perception + Primal-Urge (difficulty 7).",
         "game_line": "Werewolf: The Apocalypse",
         "category": "powers",
         "stat_type": "gift",
+        "source": "CB20 Pg. 116",
         "values": [
             3
         ],
+        "breed": "Ursine",
         "shifter_type": "Gurahl",
         "splat": "Shifter"
     },
     {
-        "name": "Restore the Land",
-        "description": "The Gurahl can heal damage done to the natural environment. A Gaia spirit teaches this Gift.",
+        "name": "Shelter of the Earth",
+        "description": "The Gurahl uses the local landscape as a secure hiding place. So long as the Gurahl doesn't move more than a few feet per turn and takes no sudden actions, he remains concealed. This Gift is taught by many prey animal spirits that rely on camouflage.",
+        "system": "The player spends a Gnosis point and rolls Dexterity + Stealth (difficulty 4). The Gift doesn't function if no cover is available.",
         "game_line": "Werewolf: The Apocalypse",
         "category": "powers",
         "stat_type": "gift",
+        "source": "CB20 Pg. 116",
         "values": [
             3
         ],
+        "breed": "Ursine",
         "shifter_type": "Gurahl",
         "splat": "Shifter"
     },
     {
-        "name": "Gift of the Bear Mother",
-        "description": "The Gurahl gains tremendous healing abilities, able to cure almost any ailment. The Bear Mother herself teaches this Gift.",
+        "name": "Safe Passage",
+        "description": "The Gurahl and those traveling with him may journey without leaving any trace of their passage. A fox-spirit teaches this Gift.",
+        "system": "The player spends one Gnosis point and rolls Dexterity + Primal-Urge. Each success beyond the first allows the werebear to include another person in the Gift's effects. It lasts for one scene.",
         "game_line": "Werewolf: The Apocalypse",
         "category": "powers",
         "stat_type": "gift",
+        "source": "CB20 Pg. 117",
+        "values": [
+            3
+        ],
+        "auspice": "Arcas",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Crush",
+        "description": "This Gift delivers a “bear-hug” from a distance, dispatching enemies without touching them. A bear-spirit teaches this Gift.",
+        "system": "The player may make grapple attacks out to a distance of (Honor) yards, as a permanent capability.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 117",
+        "values": [
+            3
+        ],
+        "auspice": "Uzmati",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Mind Sight",
+        "description": "The Gurahl may read the surface thoughts of a sentient being. Air-spirits teach this Gift.",
+        "system": "The player spends a Gnosis point and rolls Wits + Empathy (difficulty of the subject's Willpower). This mind-reading lasts for (successes rolled) turns.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 118",
+        "values": [
+            3
+        ],
+        "auspice": "Kojubat",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Waken",
+        "description": "The Gurahl may rouse an individual from supernatural sleep or unnatural slumber, including comas, vampires in torpor, Gurahl in hibernation caused by Bhernocht, and even triggering resurrection in mummies. A thunder-spirit teaches this Gift.",
+        "system": "The player spends a point of Gnosis and rolls Wits + Rituals (difficulty 7).",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 118",
+        "values": [
+            3
+        ],
+        "auspice": "Rishi",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Ways of the Tapestry",
+        "description": "The Gurahl gains insight into a mystery or puzzle, seeing how an event fits into the larger scheme of things. A cloud-spirit teaches this Gift.",
+        "system": "The player rolls Wits + Enigmas (difficulty 8). Each success provides one oblique but helpful clue about a particular problem or dilemma.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 119",
+        "values": [
+            3
+        ],
+        "auspice": "Rishi",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Masking the Hunted",
+        "description": "The Gurahl may use terrain to conceal up to 12 human or bear-sized individuals from pursuers. A bear-spirit teaches this Gift.",
+        "system": "CB20 Pg. 115",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 115",
         "values": [
             4
         ],
@@ -96,23 +415,103 @@
         "splat": "Shifter"
     },
     {
-        "name": "Strength of the Bear",
-        "description": "The Gurahl gains supernatural strength, becoming as mighty as the greatest bears. A bear-spirit teaches this Gift.",
+        "name": "Delay the Death Bear's Coming",
+        "description": "The Gurahl or a chosen ward may suffer a heroic amount of damage without dying. A cockroach-spirit teaches this Gift.",
+        "system": "The player spends a Gnosis point and rolls Wits + (Occult or Medicine), difficulty 6. Each success grants the target one additional Incapacitated health level for the rest of the scene. The Gurahl may not use this Gift on herself if she is already Incapacitated.",
         "game_line": "Werewolf: The Apocalypse",
         "category": "powers",
         "stat_type": "gift",
+        "source": "CB20 Pg. 117",
         "values": [
             4
         ],
+        "auspice": "Uzmati",
         "shifter_type": "Gurahl",
         "splat": "Shifter"
     },
     {
-        "name": "Gift of the Spirit Bear",
-        "description": "The Gurahl transforms into a mighty spirit bear, gaining tremendous power and the ability to fight spirits directly. The most powerful bear-spirits teach this Gift.",
+        "name": "Probe Thoughts",
+        "description": "This Gift enables the Gurahl to acquire hidden thoughts from an individual. A snake-spirit teaches this Gift.",
+        "system": "The player spends a Gnosis point (and a Willpower point if the target is supernatural) and rolls Wits + Empathy (difficulty of the subject's Willpower). Each success reveals one piece of information the subject is actively attempting to conceal.",
         "game_line": "Werewolf: The Apocalypse",
         "category": "powers",
         "stat_type": "gift",
+        "source": "CB20 Pg. 118",
+        "values": [
+            4
+        ],
+        "auspice": "Kojubat",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Spirit Healing",
+        "description": "The Gurahl may replenish the Essence of a wounded spirit in the Umbra. A bear-spirit teaches this Gift.",
+        "system": "The player rolls Charisma + Occult (difficulty of the spirit's Willpower). Success allows the Gurahl to spend Gnosis to restore the spirit's Essence, at a rate of two Essence per Gnosis spent.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 118",
+        "values": [
+            4
+        ],
+        "auspice": "Kieh",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Spirit Shape",
+        "description": "The Gurahl may assume the countenance and form of a creature native to the Umbra, appearing to other spirits as one of their own kind. A coyote-spirit teaches this Gift.",
+        "system": "This Gift only functions in the Umbra. The player spends a Gnosis point and rolls Appearance + Enigmas (difficulty 7). The Gurahl's body then assumes the desired appearance for (Wisdom) days. The Gurahl can will the Gift to end earlier if he requires.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 118",
+        "values": [
+            4
+        ],
+        "auspice": "Kieh",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Quell Mob Rage",
+        "description": "The Gurahl can diffuse the anger of a crowd, even lynch mobs and riots. A manatee-spirit teaches this Gift.",
+        "system": "The player rolls Charisma + Leadership (difficulty of the highest Willpower rating in the crowd). The degree by which (Succor x 30) individuals reduce their hostile mood depends on the successes rolled.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 119",
+        "values": [
+            4
+        ],
+        "auspice": "Rishi",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Bestow Ursa's Blessing",
+        "description": "The Gurahl may call down the blessing of the Great Bear on another individual, granting that individual the favor of a mighty spirit. A servant of Ursa Major teaches this Gift.",
+        "system": "The player spends a Gnosis point and rolls Wits + Occult (difficulty 7) while describing the blessing she wishes to bestow. This may be an automatic success when attempting a particular endeavor, or a one-point bonus to an Attribute. The blessing lasts for (Wisdom) hours.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 119",
+        "values": [
+            4
+        ],
+        "auspice": "Rishi",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Gaia's Breath",
+        "description": "With this legendary Gift, the Gurahl may return a deceased shapeshifter to life. Bear herself teaches this Gift.?",
+        "system": "The player spends one point each of permanent Gnosis and Willpower, then rolls Charisma + Occult (difficulty 6 + the number of hours since death). Success restores life to the target with one health level restored per success. A botch opens the corpse to possession by a powerful Bane. This Gift may be attempted once and only once on a single creature.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg 116.",
         "values": [
             5
         ],
@@ -120,14 +519,136 @@
         "splat": "Shifter"
     },
     {
-        "name": "Revival",
-        "description": "The Gurahl can bring the recently dead back to life, though at great cost to themselves. The Bear Mother herself teaches this Gift.",
+        "name": "Gentle Soul",
+        "description": "The werebear's nature as a bringer of comfort and release from pain finally overwhelms the Rage simmering within. A servant of Gaia Herself teaches this Gift.",
+        "system": "The character is no longer subject to the Curse (see W20, p. 262); her Rage never leaks out to alienate those around her.",
         "game_line": "Werewolf: The Apocalypse",
         "category": "powers",
         "stat_type": "gift",
+        "source": "CB20 Pg 116.",
         "values": [
             5
         ],
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Charismatic Presence",
+        "description": "The Gurahl exudes a compelling aura of attraction to humans. In the first days, the werebears sometimes used this Gift to place themselves at the center of tribal bear-cults in Europe, Asia, and North America. They were thus able to form strong ties between Gaia and their human kinfolk.",
+        "system": "The player rolls Charisma + Empathy (difficulty 8). The number of successes indicates the size of her following, according to the following table. Affected humans (who must be within sight of the Gurahl as she uses the Gift) will not take any hostile action towards the Gurahl unless the Gural somehow breaks their trust, and they are willing to listen to whatever she has to say (-3 difficulty to any Social rolls). Successes - Size of Following / 1 - 5 individuals. 2 - 10 3 - 20 4 - 50 5+ - 100+",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "Gurahl Breedbook Pg. 91",
+        "values": [
+            5
+        ],
+        "breed": "Homid",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Natural State",
+        "description": "The Gurahl may cause a portion of the land to revert to its original wild state: fields reject planted crops, clear-cut areas regain their trees, buildings and their contents lapse into ruin and disappear. This can be used both to restore oncetainted land after cleansing it and to cause chaos directed against despoilers of the wilderness. A glade child teaches this Gift.",
+        "system": "The player spends a Gnosis point and rolls Manipulation + Primal-Urge (difficulty 8). The number of successes determines the degree of reversion the land undergoes in an (Honor x 20) yard radius.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 117",
+        "values": [
+            5
+        ],
+        "auspice": "Arcas",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Humiliate",
+        "description": "By delivering a verbal assault, the Gurahl can psychologically defastate a group of opponents. In most cases, the loss of self-esteem engendered by theis Gift causses the victims to back down from a fight or flee the vicinity. Even if the opponent manages to stand their ground and fight, their attacks suffer from the belief that they will fail. A Bear spirit teaches this Gift.",
+        "system": "After the Gurahl verbally castigates her target (which may consist of up to five individuals), her player rolls Charisma + Intimidation (difficulty 8). One success enables the opponents to continue their intended attacks on the Gurahl, but every action suffers a penalty of two dice. Two or three successes cause the opponents to back down from the confrontation. Four or more successes means that the victims flee from the area. This Gift is a stronger and more permanent form of Dolorous Countenance, since it affects multiple targets. In addition, its effects persist for several days, sometimes leaving the victims (if they fail a Willpower roll) with a permanent aversion to the Gurahl who humiliated them. This Gift only works on sentient creatures; it has no affect on animals, spirits who lack the concept of feeling ashamed, or Wyrm creatures.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "Gurahl Breedbook Pg. 94",
+        "values": [
+            5
+        ],
+        "auspice": "Arcas",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Rage of the Mother Bear",
+        "description": "The anger of Mother Bear transforms the Gurahl into a whirlwind of furious motion. Ursa Major herself teaches this Gift.",
+        "system": "The player spends a Gnosis point and rolls Dexterity + Rituals, difficulty 6. Each success grants the Gurahl one extra action in the next turn, at her full dice pool.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 117",
+        "values": [
+            5
+        ],
+        "auspice": "Uzmati",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Aversion Therapy",
+        "description": "The Gurahl may attach negative emotions to a particular desire, as a form of mental conditioning. A thief, for example, may experience terror when he contemplates theft. The effect lasts for a year and a day. A servant of Coyote teaches this Gift.",
+        "system": "The player spends a Gnosis point (and a Willpower point, if the target is supernatural) and rolls Wits + Empathy (difficulty of the target's Willpower).",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 118",
+        "values": [
+            5
+        ],
+        "auspice": "Kojubat",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Image of the Sky Bear",
+        "description": "The Great She-Bear grants the Gurahl a body that glows with seven pinpoints of light similar to the seven stars of Ursa Major's constellation, allowing the Garou to perform additional acts of healing or protection. Ursa Major teaches this Gift herself.",
+        "system": "The player spends a Gnosis point and rolls Wits + Rituals. The Gurahl may then touch targets and instantly heal five lethal or bashing damage, heal three aggravated damage, or grant the target mystic armor (equivalent to Kevlar body armor) for the rest of the scene. One of the points of light on the Gurahl's body goes out each time he uses this Gift's benefits; when all the lights are extinguished, so is the Gift.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "CB20 Pg. 118",
+        "values": [
+            5
+        ],
+        "auspice": "Kieh",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Restore Sanity",
+        "description": "This Gift allows the Gural to completely restore the mind of an individual who has suffered an intense mental catastrophe or who has been deliberately driven insane by an enemy. Unlike the common Gift: Ease the Fevered Mind, this Gift does not affect chronic mental states or permanent forms of insanity, it simply restores a traumatized mind to its former state. A Jaggling of Ursa Major teaches this Gift.",
+        "system": "The player rolls Wits + Empathy and spends a point of Gnosis. Only one success is necessary to bring the Gift's recipient back from the edge of fear or trauma-induced madness. The effects of this Gift are permanent unless something else occurs to shatter the subjects mind again. This Gift cannot heal certain permanent Derangements (such as Metis disfigurements or a Malkavian's madness), although with five successes, the Gurahl can cure Harano.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "Gurahl Breedbook Pg. 99",
+        "values": [
+            5
+        ],
+        "auspice": "Kieh",
+        "shifter_type": "Gurahl",
+        "splat": "Shifter"
+    },
+    {
+        "name": "Words of Doom",
+        "description": "This Gift enables a Gurahl to curse an individual (or an allied group of individuals up to five in number), punishing them for some gross misdeed. Some werebears believe that the origin of the Silver Fangs' tribal insanity resulted from a curse placed upon them for their part in the War of Rage. Gurahl who use this Gift tread a thin line between serving Gaia and becoming a tool of the Pattern Breaker, since the pronouncement of a curse upon an individual or group often reflects adversely upon the speaker, touching her spirit with darkness. A worm spirit teaches this Gift.",
+        "system": "After the Gurahl states the terms of the curse, the player rolls Wits + Occult (difficulty 9) and sacrifices a point of permanent Gnosis to seal the effect. The words used must specifically describe the terms of the punishment along with the means for lifting or escaping the curse ('you and your descendants shall never know unsullied happiness until you return that which you stole from my people.'). If the nature of the curse is particularly harmful, detrimental, or far-reaching, the Storyteller may require the Gurahl character to give up to or even three points of permanent Gnosis instead of one.",
+        "game_line": "Werewolf: The Apocalypse",
+        "category": "powers",
+        "stat_type": "gift",
+        "source": "Gurahl Breedbook Pg. 101",
+        "values": [
+            5
+        ],
+        "auspice": "Rishi",
         "shifter_type": "Gurahl",
         "splat": "Shifter"
     }

--- a/data/possessed_blessings.json
+++ b/data/possessed_blessings.json
@@ -16,7 +16,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "General"
   },
   {
@@ -26,7 +26,7 @@
     "game_line": "Werewolf: The Apocalypse", 
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "General"
   },
 	{
@@ -36,7 +36,7 @@
 	  "game_line": "Werewolf: The Apocalypse",
 	  "category": "powers",
 	  "stat_type": "blessing",
-	  "values": [1],
+	  "values": [5],
 	  "possessed_type": "Kami"
 	},
 	{
@@ -56,7 +56,7 @@
 	  "game_line": "Werewolf: The Apocalypse",
 	  "category": "powers",
 	  "stat_type": "blessing",
-	  "values": [2],
+	  "values": [3],
 	  "possessed_type": "Fomori"
 	},
 	{
@@ -76,7 +76,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "General"
   },
   {
@@ -96,7 +96,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "General"
   },
   {
@@ -116,7 +116,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [4],
     "possessed_type": "General"
   },
   {
@@ -136,7 +136,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing", 
-    "values": [1,2,3],
+    "values": [5, 10, 15],
     "possessed_type": "General"
   },
   {
@@ -156,18 +156,18 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [2],
     "possessed_type": "General"
   },
   {
-    "name": "Size",
+    "name": "Size (Possessed)",
     "description": "While the power Size Shift allows for dramatic but temporary changes in mass, Size represents permanent changes in size and mass, both increases and decreases.",
     "system": "Size can be taken three times. Each purchase either increases or decreases the size of the Kami. Each increase adds one Health Level and one point of both Strength and Stamina. Each decrease reduces her maximum Strength and Stamina by one each, and increases the difficulty of rolls to to spot her or to hit her in combat by 1.",
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1,2,3],
-    "possessed_type": "General"
+    "values": [4, 6],
+    "possessed_type": "Kami"
   },
   {
     "name": "Size Shift",
@@ -176,7 +176,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1,2,3],
+    "values": [2, 4, 6],
     "possessed_type": "General"
   },
   {
@@ -186,8 +186,8 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1,2,3,4,5],
-    "possessed_type": "General"
+    "values": [3,6,9,12,15],
+    "possessed_type": "Kami"
   },
   {
     "name": "Spirit Charm",
@@ -196,17 +196,17 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1,2,3,4,5],
-    "possessed_type": "General"
+    "values": [1],
+    "possessed_type": "Kami"
   },
   {
     "name": "Spirit Ties",
     "description": "The possessed has an innate connection to the spirit world.",
-    "system": "This power can be bought multiple times; each time, the possessed gains one point of Gnosis (up to a maximum of 5). The possessed can't step sideways into the Umbra, but she can activate fetishes (Gaian for Kami, Bane for Fomori)",
+    "system": "The fomor has an innate connection to the spirit world. Buying this power grants the Fomor 1 point of Gnosis which they may raise as normal using XP or Bonus Points (up to a maximum of 5). The fomor can't step sideways into the Umbra, but she can activate Bane fetishes.",
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1,2,3,4,5],
+    "values": [2],
     "possessed_type": "General"
   },
   {
@@ -216,7 +216,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "General"
   },
   {
@@ -226,7 +226,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [2],
     "possessed_type": "General"
   },
   {
@@ -246,7 +246,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "General"
   },
   {
@@ -256,7 +256,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "General"
   },
   {
@@ -266,7 +266,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [2],
     "possessed_type": "Kami"
   },
   {
@@ -316,7 +316,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "Kami"
   },
   {
@@ -352,7 +352,7 @@
   {
     "name": "Ritekeeper",
     "description": "The Kami can learn Garou rites, through actually performing them is particularly taxing. Most often, they're gifted with the knowledge of a Rite so they might pass it to Garou to whom it will be most useful.",
-    "system": "The Kami knows Rites with a total level of her permanent Gnosis. In addition to any cost a Rite may have, the Kami must spend a point of Willpower to perform them. When teaching the Rite to a shapeshifter, the time it takes him to learn the rite is cut in half.",
+    "system": "The Kami knows Rites with a total level of her permanent Gnosis. In addition to any cost a Rite may have, the Kami must spend a point of Willpower to perform them. When teaching the Rite to a shapeshifter, the time it takes him to learn the rite is cut in half. Rites that are tribe specific are excluded. After purchasing one level of this blessing, the Kami is able to purcahse rites at XP cost.",
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
@@ -366,7 +366,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1,2,3,4],
+    "values": [1,4],
     "possessed_type": "Kami"
   },
   {
@@ -436,7 +436,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1,2,3],
+    "values": [2, 4, 6],
     "possessed_type": "Fomori"
   },
   {
@@ -446,7 +446,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "Fomori"
   },
   {
@@ -456,7 +456,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "Fomori"
   },
   {
@@ -476,7 +476,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "Fomori"
   },
   {
@@ -496,7 +496,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "Fomori"
   },
   {
@@ -506,7 +506,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [2],
     "possessed_type": "Fomori"
   },
   {
@@ -516,7 +516,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [2],
     "possessed_type": "Fomori"
   },
   {
@@ -526,7 +526,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [5],
     "possessed_type": "Fomori"
   },
   {
@@ -536,7 +536,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "Fomori"
   },
   {
@@ -546,7 +546,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [5],
     "possessed_type": "Fomori"
   },
   {
@@ -556,7 +556,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [2],
     "possessed_type": "Fomori"
   },
   {
@@ -566,17 +566,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
-    "possessed_type": "Fomori"
-  },
-  {
-    "name": "Fiery Discharge",
-    "description": "The fomor can spew a fiery fluid from one of its existing orifices or a new one created through mutation. The fluid could be any variant of a natural discharge. Whatever form the discharge assumes, it burns. An additional mutated gland secretes and forcefully expresses this fluid, but readying it before each burst takes time.",
-    "system": "This attack requires a Wits + Athletics roll, and normal modifiers from Firearms attacks apply. The attack can be made once every other round; the Berserker power does not allow additional attacks with the discharge. Each success on the attack roll not only increases the chance to hit, but also defines the range of the attack in yards/meters. Damage is aggravated, but it can be mitigated by Gifts like Resist Toxin.",
-    "game_line": "Werewolf: The Apocalypse",
-    "category": "powers",
-    "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "Fomori"
   },
   {
@@ -596,7 +586,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [2],
     "possessed_type": "Fomori"
   },
   {
@@ -616,7 +606,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [4],
     "possessed_type": "Fomori"
   },
   {
@@ -626,7 +616,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [2],
     "possessed_type": "Fomori"
   },
   {
@@ -636,7 +626,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "Fomori"
   },
   {
@@ -656,7 +646,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [5],
     "possessed_type": "Fomori"
   },
   {
@@ -666,7 +656,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "Fomori"
   },
   {
@@ -686,7 +676,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [5],
     "possessed_type": "Fomori"
   },
   {
@@ -696,7 +686,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "Fomori"
   },
   {
@@ -706,7 +696,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "Fomori"
   },
   {
@@ -716,7 +706,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [4],
     "possessed_type": "Fomori"
   },
   {
@@ -726,7 +716,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [2],
     "possessed_type": "Fomori"
   },
   {
@@ -736,7 +726,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "Fomori"
   },
   {
@@ -746,7 +736,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [2],
     "possessed_type": "Fomori"
   },
   {
@@ -756,7 +746,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "Fomori"
   },
   {
@@ -766,17 +756,17 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "Fomori"
   },
   {
-    "name": "Rat Head",
+    "name": "Rat Head (Possessed)",
     "description": "Did you know rats have a collapsible skeletal structure that allows them to squeeze through holes about the size of their skull? The fomor with this power can wriggle through holes as small as 5% of its ordinary circumference. Like a tiny, mischievous rat, a human-sized fomor can squeeze through a hole about the size of a quarter.",
     "system": "The fomor rolls Dexterity + Athletics (difficulty 6). The effects last for one 'slide' through a hole (until the fomor reaches an area wider than its original size). A failed roll means the fomor is stuck; this requires further attempts, but each successive attempt increases the difficulty by one. While squeezing like this, the fomor can move at half her normal running speed.",
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [2],
     "possessed_type": "Fomori"
   },
   {
@@ -786,7 +776,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [5],
     "possessed_type": "Fomori"
   },
   {
@@ -796,7 +786,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [5],
     "possessed_type": "Fomori"
   },
   {
@@ -806,7 +796,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [2],
     "possessed_type": "Fomori"
   },
   {
@@ -816,7 +806,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "Fomori"
   },
   {
@@ -846,8 +836,58 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [2],
     "possessed_type": "Fomori"
+  },
+    {
+    "name": "Moonstone",
+    "description": "This power gives the Kami's body properties similar to a caern's pathstone, allowing Moon Bridges to link directly to her person.",
+    "system": " This power does not automatically confer the Rite of the Opening Bridge, though it makes that rite possible within the bounds of the Kami herself. The Kami must also purchase the power Spirit Den to purchase Moonstone.",
+    "game_line": "Werewolf: The Apocalypse",
+    "category": "powers",
+    "stat_type": "blessing",
+    "values": [4],
+    "possessed_type": "Kami"
+  },
+    {
+    "name": "Wellspring",
+    "description": "The Kami acts in much the same manner as a caern, providing spiritual sustenance for any shapeshifters who spent enough time in her boundaries.",
+    "system": "The Kami spends two points of Gnosis per caern level, up to ten points to make a Level 5 caern. For the next lunar month, she is a caern of that level for all purposes, though she does not have a type. The Kami can terminate this power at any time before the end of the month. When it ends, she regains half of the Gnosis she invested to become a caern. All Rorqual possess this power for free. ",
+    "game_line": "Werewolf: The Apocalypse",
+    "category": "powers",
+    "stat_type": "blessing",
+    "values": [5],
+    "possessed_type": "Kami"
+  },
+      {
+    "name": "Enchanting Voice",
+    "description": "They may entralll listeners with a song.",
+    "system": "As long as the character sings, anyone within the area must make a Willpower roll (resisted by the character's Charisma + Performance) to take any action other than listen to the song. If the listeners are aware of some form of impending or even present danger, they receive three additional dice on the roll. If they are wounded while listening to the song, the effect of the character's voice is broken. The possessed character's voice has no power to influence listeners in other ways (barring other powers of similar nature, such as Spirit Gift: Roll Over).",
+    "game_line": "Werewolf: The Apocalypse",
+    "category": "powers",
+    "stat_type": "blessing",
+    "values": [1],
+    "possessed_type": "Kami"
+  },
+    {
+    "name": "Safe Place",
+    "description": "This power effectively removes access to the Kami from the Umbra. She has no Penumbral shadow, and attempts to Step Sideways near her are tremendously difficult. Even when successful, they simply eject the invader at the Kami's nearest boundary.",
+    "system": "The Gauntlet around the Kami out to (Gnosis x5) yards becomes a staggering difficulty 9 to cross for travelers in the Umbra. Success does not place the potential invader on the Kami herself, but just outside the area of increased Gauntlet.",
+    "game_line": "Werewolf: The Apocalypse",
+    "category": "powers",
+    "stat_type": "blessing",
+    "values": [3],
+    "possessed_type": "Kami"
+  },
+    {
+    "name": "Spirit Den",
+    "description": "The Gauntlet of the Kami's land-body is thin enough that passing through the Kami's center is as effective as Stepping Sideways into the Umbra. Her reflection in the Penumbra is identical to her earthly body.",
+    "system": "No roll is needed to pass from the Umbra to the Kami, and vice versa. If this power is taken with Safe Place, treat the reflection as if the Rite of the Shrouded Glen (W20, p.207) has been performed successfully.",
+    "game_line": "Werewolf: The Apocalypse",
+    "category": "powers",
+    "stat_type": "blessing",
+    "values": [3],
+    "possessed_type": "Kami"
   },
   {
     "name": "Stomach Pumper",
@@ -856,7 +896,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [2],
     "possessed_type": "Fomori"
   },
   {
@@ -866,7 +906,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [4],
     "possessed_type": "Fomori"
   },
   {
@@ -876,7 +916,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1,2,3,4,5],
+    "values": [2, 4, 6, 8, 10],
     "possessed_type": "Fomori"
   },
   {
@@ -886,7 +926,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [2],
     "possessed_type": "Fomori"
   },
   {
@@ -896,7 +936,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "Fomori"
   },
   {
@@ -906,7 +946,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [4],
     "possessed_type": "Fomori"
   },
   {
@@ -916,7 +956,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [4],
     "possessed_type": "Fomori"
   },
   {
@@ -926,7 +966,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [3],
     "possessed_type": "Fomori"
   },
   {
@@ -936,7 +976,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [4],
     "possessed_type": "Fomori"
   },
   {
@@ -946,7 +986,7 @@
     "game_line": "Werewolf: The Apocalypse",
     "category": "powers",
     "stat_type": "blessing",
-    "values": [1],
+    "values": [2],
     "possessed_type": "Fomori"
   },
   {

--- a/data/possessed_flaws.json
+++ b/data/possessed_flaws.json
@@ -1,21 +1,21 @@
 [
 	{
 	  "name": "Spirit's Mark (Flaw)",
-	  "description": "The spirit riding you bleeds over into the physical world a bit. You aren’t physically any different (not as a result of this Trait, anyway) but you exude a certain aura. What exactly that aura feels like depends on a) whether Spirit’s Mark is a Merit or a Flaw and b) what kind of spirit possesses you. An attractive fomor might reek of pure lust, granting a -2 on all Seduction-related difficulties. A Kami possesses by a predator-spirit might engender a feeling similar to the Curse in humans (+1 to Social difficulties not related to Intimidation). The Storyteller should work with the player to decide what kind of feeling the character gives off and how it translates into game play. Generally, it should be worth a difficulty adjustment of 1 or 2, depending on how specific the feeling is.",
+	  "description": "The spirit riding you bleeds over into the physical world a bit. You aren't physically any different (not as a result of this Trait, anyway) but you exude a certain aura. What exactly that aura feels like depends on a) whether Spirit's Mark is a Merit or a Flaw and b) what kind of spirit possesses you. An attractive fomor might reek of pure lust, granting a -2 on all Seduction-related difficulties. A Kami possesses by a predator-spirit might engender a feeling similar to the Curse in humans (+1 to Social difficulties not related to Intimidation). The Storyteller should work with the player to decide what kind of feeling the character gives off and how it translates into game play. Generally, it should be worth a difficulty adjustment of 1 or 2, depending on how specific the feeling is.",
 	  "system": "",
 	  "game_line": "Werewolf: The Apocalypse",
 	  "category": "flaws",
-	  "stat_type": "",
+	  "stat_type": "supernatural",
 	  "values": [2],
 	  "possessed_type": "General"
 	},
 	{
 	  "name": "Known to the Enemy",
-	  "description": "	They've got your number. Someone on the other side knows about you, what you are, and has a general idea of where to find you. If you're a fomor, this might be a Garou or another Gaian shapeshifter. If you're a Kami, this might be a Black Spiral Dancer, perhaps, or a powerful fomor. This Flaw doesn't assume that the enemy is actively hunting you, but if you do anything too conspicuous, they might decide that you're worth the attention.",
+	  "description": "They've got your number. Someone on the other side knows about you, what you are, and has a general idea of where to find you. If you're a fomor, this might be a Garou or another Gaian shapeshifter. If you're a Kami, this might be a Black Spiral Dancer, perhaps, or a powerful fomor. This Flaw doesn't assume that the enemy is actively hunting you, but if you do anything too conspicuous, they might decide that you're worth the attention.",
 	  "system": "",
 	  "game_line": "Werewolf: The Apocalypse",
 	  "category": "flaws",
-	  "stat_type": "",
+	  "stat_type": "social",
 	  "values": [3],
 	  "possessed_type": "General"
 	},
@@ -25,18 +25,18 @@
 	  "system": "",
 	  "game_line": "Werewolf: The Apocalypse",
 	  "category": "flaws",
-	  "stat_type": "",
+	  "stat_type": "physical",
 	  "values": [1],
 	  "possessed_type": "General"
 	},
 	{
 	  "name": "Scary Presence",
-	  "description": "The Wyrm rides you always; no matter how you act or appear, you're cursed to frighten people by your very presence. This Flaw has no physical manifestation — you scare folks simply by existing. Mundane humans will avoid you however they can, and may become violent if pressed. Even other fomori will sense the taint that infects your soul; they may not flee, but you won’t be popular, either. Loneliness is your lot forever.",
+	  "description": "The Wyrm rides you always; no matter how you act or appear, you're cursed to frighten people by your very presence. This Flaw has no physical manifestation — you scare folks simply by existing. Mundane humans will avoid you however they can, and may become violent if pressed. Even other fomori will sense the taint that infects your soul; they may not flee, but you won't be popular, either. Loneliness is your lot forever.",
 	  "system": "",
 	  "game_line": "Werewolf: The Apocalypse",
 	  "category": "flaws",
-	  "stat_type": "",
+	  "stat_type": "supernatural",
 	  "values": [2],
 	  "possessed_type": "Fomori"
-	},
+	}
 ]

--- a/data/possessed_merits.json
+++ b/data/possessed_merits.json
@@ -1,42 +1,42 @@
 [
 	{
 	  "name": "Spirit's Mark (Merit)",
-	  "description": "The spirit riding you bleeds over into the physical world a bit. You aren’t physically any different (not as a result of this Trait, anyway) but you exude a certain aura. What exactly that aura feels like depends on a) whether Spirit’s Mark is a Merit or a Flaw and b) what kind of spirit possesses you. An attractive fomor might reek of pure lust, granting a -2 on all Seduction-related difficulties. A Kami possesses by a predator-spirit might engender a feeling similar to the Curse in humans (+1 to Social difficulties not related to Intimidation). The Storyteller should work with the player to decide what kind of feeling the character gives off and how it translates into game play. Generally, it should be worth a difficulty adjustment of 1 or 2, depending on how specific the feeling is.",
+	  "description": "The spirit riding you bleeds over into the physical world a bit. You aren't physically any different (not as a result of this Trait, anyway) but you exude a certain aura. What exactly that aura feels like depends on a) whether Spirit's Mark is a Merit or a Flaw and b) what kind of spirit possesses you. An attractive fomor might reek of pure lust, granting a -2 on all Seduction-related difficulties. A Kami possesses by a predator-spirit might engender a feeling similar to the Curse in humans (+1 to Social difficulties not related to Intimidation). The Storyteller should work with the player to decide what kind of feeling the character gives off and how it translates into game play. Generally, it should be worth a difficulty adjustment of 1 or 2, depending on how specific the feeling is.",
 	  "system": "",
 	  "game_line": "Werewolf: The Apocalypse",
-	  "category": "flaws",
-	  "stat_type": "",
+	  "category": "merits",
+	  "stat_type": "supernatural",
 	  "values": [2],
 	  "possessed_type": "General"
 	},
 	{
 	  "name": "Banespeak",
-	  "description": "	With your transformation, you have discovered a way into your dark spiritual side and are able to speak with the Bane part of yourself. When you speak with your Bane, you appear to be talking animatedly to yourself. Your Bane whispers dark secrets to the tattered remains of your soul, and your soul withers a little more with each vile revelation. Your Storyteller will create the Bane, but will not reveal to you the extent of its knowledge or its secret powers. While your Bane will not guide you all the time, at moments of deep urgency it may be able to provide you with clues or information about the Wyrm or Garou worlds which you would not otherwise know.",
+	  "description": "With your transformation, you have discovered a way into your dark spiritual side and are able to speak with the Bane part of yourself. When you speak with your Bane, you appear to be talking animatedly to yourself. Your Bane whispers dark secrets to the tattered remains of your soul, and your soul withers a little more with each vile revelation. Your Storyteller will create the Bane, but will not reveal to you the extent of its knowledge or its secret powers. While your Bane will not guide you all the time, at moments of deep urgency it may be able to provide you with clues or information about the Wyrm or Garou worlds which you would not otherwise know.",
 	  "system": "",
 	  "game_line": "Werewolf: The Apocalypse",
 	  "category": "merits",
-	  "stat_type": "",
+	  "stat_type": "supernatural",
 	  "values": [3],
 	  "possessed_type": "Fomori"
 	},
 	{
 	  "name": "Hidden Power",
-	  "description": "	None of your Powers or Taints are physically obvious. You appear to be human (or whatever you were before becoming a fomor). If you have extra limbs or body barbs, they are retractable and hidden under a sheath of skin. You seem to be one of the crowd.",
+	  "description": "None of your Powers or Taints are physically obvious. You appear to be human (or whatever you were before becoming a fomor). If you have extra limbs or body barbs, they are retractable and hidden under a sheath of skin. You seem to be one of the crowd.",
 	  "system": "",
 	  "game_line": "Werewolf: The Apocalypse",
-	  "category": "flaws",
-	  "stat_type": "",
+	  "category": "merits",
+	  "stat_type": "supernatural",
 	  "values": [1],
 	  "possessed_type": "Fomori"
 	},
 	{
 	  "name": "Stigmata of the Wyrm",
-	  "description": "	These are marks of the Urge Wyrms which sometimes commune with favored servants. To “win” one, a fomor must first understand the aspects of the Wyrm (which indicates some level of insanity to begin with), then contact her own inner corruption (to discover which aspect favors her), manifest that Urge in word, body and deed, and often undergo some hideous ordeal of consecration. Seeking the Wyrm within often requires a perverted visionquest; this usually involves breaking away from all friends (including other fomori), and indulging in some excess related to the vision your character seeks until some truth appears. These excesses can include killing sprees, near-fatal drug binges, wanton cruelty (brutalizing homeless folks, children, animals, etc.), prolonged depressions, psychotic episodes, mad orgies and other deadly activities. At some point, a vision of the Urge Wyrm’s Malign Incarna appears to the fortunate one and sends her through some excruciating test of loyalty; such ordeals are related to the Urge Wyrm involved — tests of greed, cruelty, deceit, etc. A fomor who survives the test (many do not) receives the mark of favor. Like the tests, stigmata marks relate to the Urge Wyrm the character serves: Pesuak, Lord of Lies, often gifts his chosen with forked tongues. Karnala, Desire’s Urge, has more attractive marks, often hypnotically intriguing tattoos. Foobok gifts his followers with forever-open eyes, while Pizak’s mark consists of massive brands which never heal. The exact nature of the mark is left to the troupe’s imagination, but it should reflect some appropriately deviant behavior. Stigmata can be really useful in social situations with others who understand the mark; Black Spiral Dancers may revere the chosen (or may kill her anyway — they are demented, after all!), and Pentex superiors and Wyrm-mystics will give her respect. Even humans who embrace the Urge Wyrm’s principles will regard the chosen one with a measure of awe and reverence. Stigmata are usually worth one to three extra dice for Social rolls when dealing with the Wyrm-tainted. Naturally, the character will stand out like a beacon to Sense Wyrm and other such Gifts, and must continue to serve the Urge Wyrm whenever possible.",
+	  "description": "These are marks of the Urge Wyrms which sometimes commune with favored servants. To “win” one, a fomor must first understand the aspects of the Wyrm (which indicates some level of insanity to begin with), then contact her own inner corruption (to discover which aspect favors her), manifest that Urge in word, body and deed, and often undergo some hideous ordeal of consecration. Seeking the Wyrm within often requires a perverted visionquest; this usually involves breaking away from all friends (including other fomori), and indulging in some excess related to the vision your character seeks until some truth appears. These excesses can include killing sprees, near-fatal drug binges, wanton cruelty (brutalizing homeless folks, children, animals, etc.), prolonged depressions, psychotic episodes, mad orgies and other deadly activities. At some point, a vision of the Urge Wyrm's Malign Incarna appears to the fortunate one and sends her through some excruciating test of loyalty; such ordeals are related to the Urge Wyrm involved — tests of greed, cruelty, deceit, etc. A fomor who survives the test (many do not) receives the mark of favor. Like the tests, stigmata marks relate to the Urge Wyrm the character serves: Pesuak, Lord of Lies, often gifts his chosen with forked tongues. Karnala, Desire's Urge, has more attractive marks, often hypnotically intriguing tattoos. Foobok gifts his followers with forever-open eyes, while Pizak's mark consists of massive brands which never heal. The exact nature of the mark is left to the troupe's imagination, but it should reflect some appropriately deviant behavior. Stigmata can be really useful in social situations with others who understand the mark; Black Spiral Dancers may revere the chosen (or may kill her anyway — they are demented, after all!), and Pentex superiors and Wyrm-mystics will give her respect. Even humans who embrace the Urge Wyrm's principles will regard the chosen one with a measure of awe and reverence. Stigmata are usually worth one to three extra dice for Social rolls when dealing with the Wyrm-tainted. Naturally, the character will stand out like a beacon to Sense Wyrm and other such Gifts, and must continue to serve the Urge Wyrm whenever possible.",
 	  "system": "",
 	  "game_line": "Werewolf: The Apocalypse",
-	  "category": "flaws",
-	  "stat_type": "",
+	  "category": "merits",
+	  "stat_type": "supernatural",
 	  "values": [4],
 	  "possessed_type": "Fomori"
-	},
+	}
 ]

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -721,7 +721,7 @@ class Character(DefaultCharacter):
             # Special handling for Changelings looking at other Changelings or Kinain
             if target_splat == 'Changeling' or is_kinain:
                 looker.msg("|mMore about this {} is hidden beyond mortal eyes...|n".format(
-                    "Kithain" if target_splat == 'Changeling' else "Kinain"
+                    "Fae" if target_splat == 'Changeling' else "Kinain"
                 ))
             else:
                 # Get target's Banality from pools.dual

--- a/wiki/admin.py
+++ b/wiki/admin.py
@@ -30,18 +30,21 @@ class FeaturedImageInline(admin.StackedInline):
 class WikiPageAdmin(admin.ModelAdmin):
     """Admin interface for wiki pages."""
     
-    list_display = ('title', 'creator', 'created_at', 'last_editor', 'updated_at', 'is_featured', 'featured_order', 'published')
-    list_filter = ('created_at', 'updated_at', 'is_featured', 'is_index', 'published')
-    search_fields = ('title', 'content')
+    list_display = ('title', 'page_type', 'creator', 'created_at', 'last_editor', 'updated_at', 'is_featured', 'featured_order', 'published')
+    list_filter = ('page_type', 'created_at', 'updated_at', 'is_featured', 'is_index', 'published')
+    search_fields = ('title', 'content', 'brief_description')
     prepopulated_fields = {'slug': ('title',)}
     inlines = [FeaturedImageInline]
     filter_horizontal = ('related_to',)
     list_editable = ('is_featured', 'featured_order', 'published')
     ordering = ('featured_order', 'title')
     
+    class Media:
+        js = ('wiki/js/admin-page-type.js',)
+    
     fieldsets = (
         (None, {
-            'fields': ('title', 'slug', 'content', 'right_content')
+            'fields': ('title', 'slug', 'page_type', 'brief_description', 'content', 'right_content')
         }),
         ('Options', {
             'fields': ('is_featured', 'is_index', 'related_to'),

--- a/wiki/static/wiki/css/styles.css
+++ b/wiki/static/wiki/css/styles.css
@@ -1515,3 +1515,510 @@ body.menu-open {
     margin-top: 0.25em;
 }
 
+.wiki-pages {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    border-radius: 0;
+    background-color: transparent;
+}
+
+.wiki-pages .list-group-item {
+    margin-bottom: 10px;
+    border-radius: 0;
+    background-color: rgba(0, 0, 0, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    transition: all 0.3s ease;
+}
+
+.wiki-pages .list-group-item:hover {
+    background-color: rgba(0, 0, 0, 0.8);
+    border-color: rgba(255, 255, 255, 0.5);
+}
+
+.wiki-pages h5 {
+    margin-bottom: 5px;
+    font-family: 'impact_label_reversed', Arial, sans-serif;
+    letter-spacing: 2px;
+    font-size: 22px;
+    color: rgba(213, 96, 91, 1);
+}
+
+.wiki-pages small {
+    color: rgba(255, 255, 255, 0.7);
+    font-family: 'analog_typewriter', Arial, sans-serif;
+    font-size: 14px;
+}
+
+.edit-controls {
+    margin-bottom: 20px;
+    display: flex;
+    gap: 10px;
+}
+
+.edit-controls .btn {
+    padding: 8px 15px;
+    border-radius: 0;
+    font-family: 'impact_label_reversed', Arial, sans-serif;
+    letter-spacing: 2px;
+    font-size: 16px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    transition: all 0.3s ease;
+}
+
+.edit-controls .btn-primary {
+    background-color: rgba(213, 96, 91, 0.8);
+    color: #fff;
+}
+
+.edit-controls .btn-primary:hover {
+    background-color: rgba(213, 96, 91, 1);
+}
+
+.edit-controls .btn-secondary {
+    background-color: rgba(0, 0, 0, 0.6);
+    color: #fff;
+}
+
+.edit-controls .btn-secondary:hover {
+    background-color: rgba(0, 0, 0, 0.8);
+}
+
+.content {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+    width: 100%;
+    margin-top: 90px;
+    padding: 0 20px;
+    flex-grow: 1;
+    overflow: auto;
+}
+
+.content form {
+    max-width: 100%;
+    display: block;
+    width: 100%;
+}
+
+.form-group {
+    margin-bottom: 20px;
+    width: 100%;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 8px;
+    font-family: 'impact_label_reversed', Arial, sans-serif;
+    font-size: 18px;
+    letter-spacing: 2px;
+    color: #fff;
+}
+
+.form-control {
+    width: 100%;
+    padding: 10px;
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    color: #fff;
+    font-family: 'roboto mono', monospace;
+}
+
+.btn {
+    padding: 10px 20px;
+    font-family: 'impact_label_reversed', Arial, sans-serif;
+    letter-spacing: 2px;
+    background: #000;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    color: #fff;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.btn-primary {
+    background-color: rgba(213, 96, 91, 0.8);
+}
+
+.btn-primary:hover {
+    background-color: rgba(213, 96, 91, 1);
+}
+
+.image-upload-section {
+    margin-top: 20px;
+    padding: 15px;
+    border: 1px dashed rgba(255, 255, 255, 0.3);
+    background: rgba(0, 0, 0, 0.3);
+}
+
+.image-upload-section h3 {
+    margin-top: 0;
+    font-size: 18px;
+}
+
+.creation-form-container {
+    width: 100%;
+    max-width: 100%;
+}
+
+.creation-form-container form {
+    width: 100%;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.edit-mode {
+    display: flex;
+    flex-direction: column;
+}
+
+.edit-mode .main-content {
+    width: 100%;
+    max-width: 100%;
+}
+
+.edit-mode form {
+    width: 100%;
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.edit-mode .form-group {
+    margin-bottom: 20px;
+}
+
+.edit-mode .form-group label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: bold;
+}
+
+.edit-mode .form-group input[type="text"],
+.edit-mode .form-group input[type="email"],
+.edit-mode .form-group input[type="password"],
+.edit-mode .form-group select,
+.edit-mode .form-group textarea {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.edit-mode .form-group textarea {
+    min-height: 200px;
+}
+
+.edit-mode .button-group {
+    margin-top: 20px;
+    text-align: center;
+}
+
+.edit-mode .button-group button {
+    padding: 10px 20px;
+    background-color: #333;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.edit-mode .button-group button:hover {
+    background-color: #555;
+}
+
+/* Player Editor Styles */
+.content-preview {
+    background-color: rgba(0, 0, 0, 0.5);
+    border: 1px solid rgba(255, 255, 255, 0.3) !important;
+    padding: 20px !important;
+    margin-top: 20px;
+    color: #fff;
+}
+
+.content-preview h3 {
+    font-family: 'impact_label_reversed', Arial, sans-serif;
+    font-size: 22px;
+    margin-bottom: 15px;
+    background-color: transparent;
+    padding: 0;
+}
+
+.content-preview #preview-content {
+    font-family: 'roboto mono', monospace;
+    line-height: 1.6;
+}
+
+/* Alert styling */
+.alert-container {
+    margin-bottom: 20px;
+}
+
+.alert {
+    padding: 15px;
+    margin-bottom: 10px;
+    border: 1px solid transparent;
+    border-radius: 0;
+}
+
+.alert-success {
+    color: #155724;
+    background-color: #d4edda;
+    border-color: #c3e6cb;
+}
+
+.alert-danger {
+    color: #721c24;
+    background-color: #f8d7da;
+    border-color: #f5c6cb;
+}
+
+.alert-warning {
+    color: #856404;
+    background-color: #fff3cd;
+    border-color: #ffeeba;
+}
+
+.alert-info {
+    color: #0c5460;
+    background-color: #d1ecf1;
+    border-color: #bee5eb;
+}
+
+/* Button styles */
+.btn-info {
+    background-color: rgba(23, 162, 184, 0.8);
+    border-color: rgba(23, 162, 184, 0.5);
+    color: white;
+}
+
+.btn-info:hover {
+    background-color: rgba(23, 162, 184, 1);
+}
+
+/* Actions container */
+.actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+}
+
+.preview-container {
+    flex-basis: 100%;
+    margin-top: 15px;
+}
+
+/* Style the editor toolbar */
+.editor-toolbar {
+    background-color: rgba(255, 255, 255, 0.05) !important;
+    border-color: rgba(255, 255, 255, 0.2) !important;
+}
+
+.editor-toolbar button {
+    color: rgba(255, 255, 255, 0.8) !important;
+}
+
+.editor-toolbar button:hover,
+.editor-toolbar button.active {
+    background-color: rgba(255, 255, 255, 0.1) !important;
+    border-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+.CodeMirror {
+    background-color: rgba(0, 0, 0, 0.3) !important;
+    color: rgba(255, 255, 255, 0.9) !important;
+    border-color: rgba(255, 255, 255, 0.2) !important;
+}
+
+.CodeMirror-cursor {
+    border-left: 1px solid #fff !important;
+}
+
+.CodeMirror-selected {
+    background-color: rgba(255, 255, 255, 0.2) !important;
+}
+
+.CodeMirror-line {
+    color: rgba(255, 255, 255, 0.9) !important;
+}
+
+/* Required field styling */
+input:required, textarea:required {
+    border-left: 3px solid rgba(213, 96, 91, 0.8);
+}
+
+/* Editing guidelines styling */
+.sidebar h2:nth-of-type(2) {
+    margin-top: 30px;
+}
+
+.sidebar h2:nth-of-type(2) + ul li {
+    color: rgba(255, 255, 255, 0.8);
+}
+
+/* Make formatting examples more readable */
+.sidebar h2:nth-of-type(3) + ul li {
+    font-family: 'roboto mono', monospace;
+    font-size: 13px;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+/* Content Header styling */
+.content-header {
+    width: 100%;
+    margin-bottom: 40px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+    padding-bottom: 20px;
+}
+
+.content-header h1 {
+    width: 100%;
+    margin-bottom: 20px;
+    font-size: 36px;
+    letter-spacing: 6px;
+}
+
+.content-header p {
+    margin-bottom: 30px;
+    font-family: 'roboto mono', monospace;
+    font-size: 16px;
+    color: #fff;
+    line-height: 1.6;
+    max-width: 800px;
+}
+
+.header-actions {
+    display: flex;
+    gap: 15px;
+    margin-bottom: 20px;
+}
+
+.header-actions .btn {
+    padding: 8px 16px;
+    background-color: rgba(0, 0, 0, 0.7);
+    border: 1px solid rgba(213, 96, 91, 0.7);
+    color: rgba(213, 96, 91, 1);
+    font-family: 'impact_label_reversed', Arial, sans-serif;
+    letter-spacing: 2px;
+    font-size: 16px;
+    transition: all 0.3s ease;
+}
+
+.header-actions .btn:hover {
+    background-color: rgba(213, 96, 91, 0.2);
+    color: rgba(255, 255, 255, 0.9);
+}
+
+/* Wiki pages list styling */
+.wiki-pages {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.wiki-pages .list-group {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+    width: 100%;
+}
+
+.wiki-pages .list-group-item {
+    background-color: rgba(0, 0, 0, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 15px 20px;
+    transition: all 0.3s ease;
+    display: block;
+    color: #fff;
+    text-decoration: none;
+}
+
+.wiki-pages .list-group-item:hover {
+    background-color: rgba(0, 0, 0, 0.9);
+    border-color: rgba(213, 96, 91, 0.7);
+    transform: translateY(-2px);
+}
+
+.wiki-pages .list-group-item h5 {
+    font-family: 'analog_typewriter', Arial, sans-serif;
+    font-size: 22px;
+    margin-bottom: 8px;
+    color: rgba(213, 96, 91, 1);
+    letter-spacing: 2px;
+    font-weight: normal;
+}
+
+.wiki-pages .list-group-item small {
+    font-family: 'roboto mono', monospace;
+    font-size: 14px;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+/* Make sure content area uses full width when sidebar is empty */
+.content {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    gap: 30px;
+}
+
+.content > *:only-child {
+    width: 100%;
+}
+
+/* Full width wiki pages styling */
+.wiki-pages.full-width {
+    width: 100%;
+    max-width: 100%;
+    margin: 0;
+}
+
+.wiki-pages.full-width .list-group {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 10px;
+}
+
+/* Ensure each item gets full width in the vertical layout */
+.wiki-pages.full-width .list-group-item {
+    width: 100%;
+    margin-bottom: 15px;
+    display: block;
+}
+
+/* Make sure content column takes full width when needed */
+.content > div:only-child {
+    width: 100%;
+    max-width: 100%;
+}
+
+/* Override the right column completely */
+.content:has(.wiki-pages.full-width) {
+    display: block;
+    width: 100%;
+}
+
+/* Layout adjustments for the new vertical design */
+@media (max-width: 1600px) {
+    .wiki-pages.full-width .list-group {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* Brief description styling in list items */
+.wiki-pages .list-group-item .brief-description {
+    font-family: 'roboto mono', monospace;
+    font-size: 15px;
+    color: rgba(255, 255, 255, 0.85);
+    margin: 8px 0 10px 0;
+    line-height: 1.4;
+    padding-left: 5px;
+    border-left: 2px solid rgba(213, 96, 91, 0.5);
+}
+
+/* Ensure proper spacing in list items with descriptions */
+.wiki-pages .list-group-item:has(.brief-description) small {
+    margin-top: 5px;
+    display: block;
+}
+

--- a/wiki/templates/wiki/base_edit.html
+++ b/wiki/templates/wiki/base_edit.html
@@ -1,0 +1,82 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link rel="stylesheet" href="{% static 'wiki/css/styles.css' %}?v=1" type="text/css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
+        <link rel="icon" type="image/png" href="{% static 'wiki/imgs/favicon.png' %}">
+        <title>{% block titleblock %}Dies Irae Wiki{% endblock %}</title>
+        <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
+        <script src="{% static 'wiki/js/main.js' %}?v=1" defer></script>
+    </head>
+
+    <body>
+        <!-- Navigation -->
+        <nav class="main-nav">
+            <div class="nav-wrapper">
+                <div class="nav-container">
+                    <div class="nav-logo">
+                        <p>Dies Irae</p>
+                    </div>
+                    <ul class="nav-menu">
+                        <li><a href="/">Home</a></li>
+                        <li><a href="/characters/">Characters</a></li>
+                        <li class="dropdown">
+                            <a href="{% url 'wiki:page_list' %}" class="dropdown-toggle">Wiki</a>
+                            <ul class="dropdown-menu">
+                                <li><a href="{% url 'wiki:page_list' %}">All Pages</a></li>
+                                <li><a href="{% url 'wiki:groups_index' %}">Groups</a></li>
+                                <li><a href="{% url 'wiki:plots_index' %}">Plots</a></li>
+                            </ul>
+                        </li>
+                        <li><a href="/channels/">Channels</a></li>
+                        <li><a href="/help/">Help</a></li>
+                        <li><a href="/webclient/">Play Online</a></li>
+                        {% if user.is_authenticated %}
+                            <li class="dropdown">
+                                <a href="#" class="dropdown-toggle">{{ user.username }}</a>
+                                <ul class="dropdown-menu">
+                                    <li><a href="/characters/">Manage Characters</a></li>
+                                    <hr />
+                                    <li><a href="/accounts/profile/">Profile</a></li>
+                                    <hr />
+                                    {% if user.is_staff %}
+                                    <li><a href="/admin/">Admin Panel</a></li>
+                                    <hr />
+                                    {% endif %}
+                                    <li><a href="/accounts/password_change/">Change Password</a></li>
+                                    <li><a href="/auth/logout/?next=/">Logout</a></li>
+                                </ul>
+                            </li>
+                        {% else %}
+                            <li class="login-btn"><a href="/auth/login/?next=/">Login</a></li>
+                        {% endif %}
+                    </ul>
+                </div>
+            </div>
+        </nav>
+        
+        <div class="wrapper">
+            <div class="container">
+                <!-- Content -->
+                <div class="content-container edit-mode">
+                    <div class="main-content">
+                        {% block content %}{% endblock %}
+                    </div>
+                    <div class="sidebar-content">
+                        {% block sidebar %}{% endblock %}
+                    </div>
+                </div>
+                <footer>
+                    <p>Powered by <a href="https://evennia.com">Evennia</a></p>
+                </footer>
+            </div>
+        </div>
+
+        {% block extrajs %}{% endblock %}
+    </body>
+</html> 

--- a/wiki/templates/wiki/base_wiki.html
+++ b/wiki/templates/wiki/base_wiki.html
@@ -12,41 +12,53 @@
         <script>
             // Configure marked options
             marked.setOptions({
-                breaks: true,
-                gfm: true,
-                html: true,
-                headerIds: true,
-                sanitize: false,
-                listIndent: 2,
+                breaks: true,          // Add line breaks on single newlines
+                gfm: true,             // Use GitHub Flavored Markdown
+                html: true,            // Allow HTML in the source
+                headerIds: true,       // Include IDs in headers
+                sanitize: false,       // Allow HTML tags in output
+                listIndent: 2,         // Indent of nested lists
                 renderer: new marked.Renderer(),
-                pedantic: false,
-                mangle: true,
-                smartLists: true,
-                smartypants: true
+                pedantic: false,       // Don't be too strict with original markdown spec
+                mangle: true,          // Escape autolinks
+                smartLists: true,      // Use smarter list behavior
+                smartypants: true      // Use "smart" typographic punctuation
             });
 
             // Pre-process the content
             document.addEventListener('DOMContentLoaded', function() {
-                const leftContentData = `{{ page.content|escapejs }}`;
-                const rightContentData = `{{ page.right_content|escapejs }}`;
-                
-                console.log("Raw Left Content:", leftContentData);
-                console.log("Raw Right Content:", rightContentData);
-                
-                // Process left content
-                const leftContentElement = document.querySelector('.left_content');
-                if (leftContentElement && leftContentData) {
-                    const processedLeftContent = marked.parse(leftContentData);
-                    console.log("Processed Left Content:", processedLeftContent);
-                    leftContentElement.innerHTML = processedLeftContent;
-                }
-                
-                // Process right content
-                const rightContentElement = document.querySelector('.right_content');
-                if (rightContentElement && rightContentData) {
-                    const processedRightContent = marked.parse(rightContentData);
-                    console.log("Processed Right Content:", processedRightContent);
-                    rightContentElement.innerHTML = processedRightContent;
+                try {
+                    // Get content data from the template
+                    const leftContentData = `{{ page.content|escapejs }}`;
+                    const rightContentData = `{{ page.right_content|escapejs }}`;
+                    
+                    // Process left content
+                    const leftContentElement = document.querySelector('.left_content');
+                    if (leftContentElement && leftContentData && leftContentData.trim() !== '') {
+                        try {
+                            // Always use Markdown parsing - it handles HTML content properly too
+                            const processedLeftContent = marked.parse(leftContentData);
+                            leftContentElement.innerHTML = processedLeftContent;
+                        } catch (e) {
+                            console.error('Error parsing left content:', e);
+                            leftContentElement.textContent = leftContentData; // Fallback to plain text
+                        }
+                    }
+                    
+                    // Process right content
+                    const rightContentElement = document.querySelector('.right_content');
+                    if (rightContentElement && rightContentData && rightContentData.trim() !== '') {
+                        try {
+                            // Always use Markdown parsing - it handles HTML content properly too
+                            const processedRightContent = marked.parse(rightContentData);
+                            rightContentElement.innerHTML = processedRightContent;
+                        } catch (e) {
+                            console.error('Error parsing right content:', e);
+                            rightContentElement.textContent = rightContentData; // Fallback to plain text
+                        }
+                    }
+                } catch (e) {
+                    console.error('General error in content processing:', e);
                 }
             });
         </script>
@@ -68,8 +80,17 @@
                             <a href="{% url 'wiki:page_list' %}" class="dropdown-toggle">Wiki</a>
                             <ul class="dropdown-menu">
                                 <li><a href="{% url 'wiki:page_list' %}">All Pages</a></li>
+                                <li><a href="{% url 'wiki:groups_index' %}">Groups</a></li>
+                                <li><a href="{% url 'wiki:plots_index' %}">Plots</a></li>
+                                
+                                {% if user.is_authenticated %}
+                                <li class="dropdown-divider"><hr/></li>
+                                <li class="dropdown-header">Create</li>
                                 {% if user.is_staff %}
-                                <li><a href="/admin/wiki/wikipage/add/">Create Page</a></li>
+                                <li><a href="{% url 'wiki:create_page' %}">Regular Page</a></li>
+                                {% endif %}
+                                <li><a href="{% url 'wiki:create_group' %}">Group Page</a></li>
+                                <li><a href="{% url 'wiki:create_plot' %}">Plot Page</a></li>
                                 {% endif %}
                                 
                                 <!-- Featured Articles Section -->
@@ -78,7 +99,13 @@
                                 <li class="dropdown-header">Featured</li>
                                 {% for article in featured_articles %}
                                     <li {% if page.slug == article.slug %}class="highlight"{% endif %}>
-                                        <a href="{% url 'wiki:page_detail' article.slug %}">{{ article.title }}</a>
+                                        {% if article.page_type == 'group' %}
+                                            <a href="{% url 'wiki:group_detail' article.slug %}">{{ article.title }}</a>
+                                        {% elif article.page_type == 'plot' %}
+                                            <a href="{% url 'wiki:plot_detail' article.slug %}">{{ article.title }}</a>
+                                        {% else %}
+                                            <a href="{% url 'wiki:page_detail' article.slug %}">{{ article.title }}</a>
+                                        {% endif %}
                                     </li>
                                 {% endfor %}
                                 {% endif %}
@@ -89,16 +116,48 @@
                                 <li class="dropdown-header">Related</li>
                                 {% for article in related_articles %}
                                     <li {% if page.slug == article.slug %}class="highlight"{% endif %}>
-                                        <a href="{% url 'wiki:page_detail' article.slug %}">{{ article.title }}</a>
+                                        {% if article.page_type == 'group' %}
+                                            <a href="{% url 'wiki:group_detail' article.slug %}">{{ article.title }}</a>
+                                        {% elif article.page_type == 'plot' %}
+                                            <a href="{% url 'wiki:plot_detail' article.slug %}">{{ article.title }}</a>
+                                        {% else %}
+                                            <a href="{% url 'wiki:page_detail' article.slug %}">{{ article.title }}</a>
+                                        {% endif %}
                                     </li>
                                 {% endfor %}
                                 {% endif %}
                                 
                                 <!-- Admin Section -->
-                                {% if user.is_staff and page %}
+                                {% if user.is_staff or user.is_authenticated and page and can_edit %}
                                 <li class="dropdown-divider"><hr/></li>
                                 <li class="dropdown-header">Admin</li>
-                                <li><a href="/admin/wiki/wikipage/{{ page.id }}/change/">Edit This Page</a></li>
+                                <li><a href="{% url 'wiki:page_list' %}">Wiki Home</a></li>
+                                
+                                {% if page %}
+                                    {% if user.is_staff %}
+                                    <li><a href="/admin/wiki/wikipage/{{ page.id }}/change/">Edit This Page</a></li>
+                                    {% elif can_edit %}
+                                        {% if page.page_type == 'group' %}
+                                        <li><a href="{% url 'wiki:edit_group' page.slug %}">Edit This Page</a></li>
+                                        {% elif page.page_type == 'plot' %}
+                                        <li><a href="{% url 'wiki:edit_plot' page.slug %}">Edit This Page</a></li>
+                                        {% else %}
+                                        <li><a href="{% url 'wiki:edit_page' page.slug %}">Edit This Page</a></li>
+                                        {% endif %}
+                                    {% endif %}
+                                    <li><a href="{% url 'wiki:page_history' page.slug %}">View History</a></li>
+                                {% endif %}
+                                
+                                {% if user.is_authenticated %}
+                                    {% if user.is_staff %}
+                                    <li><a href="/admin/wiki/wikipage/add/?page_type=regular">Create Regular Page</a></li>
+                                    <li><a href="/admin/wiki/wikipage/add/?page_type=group">Create Group Page</a></li>
+                                    <li><a href="/admin/wiki/wikipage/add/?page_type=plot">Create Plot Page</a></li>
+                                    {% else %}
+                                    <li><a href="{% url 'wiki:create_group' %}">Create Group Page</a></li>
+                                    <li><a href="{% url 'wiki:create_plot' %}">Create Plot Page</a></li>
+                                    {% endif %}
+                                {% endif %}
                                 {% endif %}
                             </ul>
                         </li>
@@ -115,11 +174,14 @@
                             <li class="dropdown">
                                 <a href="#" class="dropdown-toggle">{{ user.username }}</a>
                                 <ul class="dropdown-menu">
-                                    <li><a href="/characters/create/">Create Character</a></li>
                                     <li><a href="/characters/">Manage Characters</a></li>
                                     <hr />
                                     <li><a href="/accounts/profile/">Profile</a></li>
                                     <hr />
+                                    {% if user.is_staff %}
+                                    <li><a href="/admin/">Admin Panel</a></li>
+                                    <hr />
+                                    {% endif %}
                                     <li><a href="/accounts/password_change/">Change Password</a></li>
                                     <li><a href="/auth/logout/?next=/">Logout</a></li>
                                 </ul>
@@ -163,7 +225,13 @@
                             <!-- {{ featured_articles|length }} featured articles found -->
                             {% for article in featured_articles %}
                                 <li {% if page.slug == article.slug %}class="highlight"{% endif %}>
-                                    <a href="{% url 'wiki:page_detail' article.slug %}">{{ article.title }}</a>
+                                    {% if article.page_type == 'group' %}
+                                        <a href="{% url 'wiki:group_detail' article.slug %}">{{ article.title }}</a>
+                                    {% elif article.page_type == 'plot' %}
+                                        <a href="{% url 'wiki:plot_detail' article.slug %}">{{ article.title }}</a>
+                                    {% else %}
+                                        <a href="{% url 'wiki:page_detail' article.slug %}">{{ article.title }}</a>
+                                    {% endif %}
                                 </li>
                             {% endfor %}
                         {% else %}
@@ -178,19 +246,47 @@
                         <li><h4>Related</h4></li>
                         {% for article in related_articles %}
                             <li {% if page.slug == article.slug %}class="highlight"{% endif %}>
-                                <a href="{% url 'wiki:page_detail' article.slug %}">{{ article.title }}</a>
+                                {% if article.page_type == 'group' %}
+                                    <a href="{% url 'wiki:group_detail' article.slug %}">{{ article.title }}</a>
+                                {% elif article.page_type == 'plot' %}
+                                    <a href="{% url 'wiki:plot_detail' article.slug %}">{{ article.title }}</a>
+                                {% else %}
+                                    <a href="{% url 'wiki:page_detail' article.slug %}">{{ article.title }}</a>
+                                {% endif %}
                             </li>
                         {% endfor %}
                     </ul>
                     {% endif %}
 
-                    {% if user.is_staff %}
+                    {% if user.is_staff or user.is_authenticated and page and can_edit %}
                     <ul>
                         <li><h4>Admin</h4></li>
                         <li><a href="{% url 'wiki:page_list' %}">Wiki Home</a></li>
-                        <li><a href="/admin/wiki/wikipage/add/">Create New Page</a></li>
+                        
                         {% if page %}
+                            {% if user.is_staff %}
                             <li><a href="/admin/wiki/wikipage/{{ page.id }}/change/">Edit This Page</a></li>
+                            {% elif can_edit %}
+                                {% if page.page_type == 'group' %}
+                                <li><a href="{% url 'wiki:edit_group' page.slug %}">Edit This Page</a></li>
+                                {% elif page.page_type == 'plot' %}
+                                <li><a href="{% url 'wiki:edit_plot' page.slug %}">Edit This Page</a></li>
+                                {% else %}
+                                <li><a href="{% url 'wiki:edit_page' page.slug %}">Edit This Page</a></li>
+                                {% endif %}
+                            {% endif %}
+                            <li><a href="{% url 'wiki:page_history' page.slug %}">View History</a></li>
+                        {% endif %}
+                        
+                        {% if user.is_authenticated %}
+                            {% if user.is_staff %}
+                            <li><a href="/admin/wiki/wikipage/add/?page_type=regular">Create Regular Page</a></li>
+                            <li><a href="/admin/wiki/wikipage/add/?page_type=group">Create Group Page</a></li>
+                            <li><a href="/admin/wiki/wikipage/add/?page_type=plot">Create Plot Page</a></li>
+                            {% else %}
+                            <li><a href="{% url 'wiki:create_group' %}">Create Group Page</a></li>
+                            <li><a href="{% url 'wiki:create_plot' %}">Create Plot Page</a></li>
+                            {% endif %}
                         {% endif %}
                     </ul>
                     {% endif %}
@@ -239,12 +335,31 @@
                 <!-- Wiki Section -->
                 <li class="dropdown-header">Wiki</li>
                 <li><a href="{% url 'wiki:page_list' %}">All Pages</a></li>
+                <li><a href="{% url 'wiki:groups_index' %}">Groups</a></li>
+                <li><a href="{% url 'wiki:plots_index' %}">Plots</a></li>
+                
+                {% if user.is_authenticated %}
+                <li class="dropdown-divider"><hr/></li>
+                <li class="dropdown-header">Create</li>
+                {% if user.is_staff %}
+                <li><a href="{% url 'wiki:create_page' %}">Regular Page</a></li>
+                {% endif %}
+                <li><a href="{% url 'wiki:create_group' %}">Group Page</a></li>
+                <li><a href="{% url 'wiki:create_plot' %}">Plot Page</a></li>
+                {% endif %}
+                
                 {% if featured_articles %}
                     <li class="dropdown-divider"><hr/></li>
                     <li class="dropdown-header">Featured</li>
                     {% for article in featured_articles %}
                         <li {% if page.slug == article.slug %}class="highlight"{% endif %}>
-                            <a href="{% url 'wiki:page_detail' article.slug %}">{{ article.title }}</a>
+                            {% if article.page_type == 'group' %}
+                                <a href="{% url 'wiki:group_detail' article.slug %}">{{ article.title }}</a>
+                            {% elif article.page_type == 'plot' %}
+                                <a href="{% url 'wiki:plot_detail' article.slug %}">{{ article.title }}</a>
+                            {% else %}
+                                <a href="{% url 'wiki:page_detail' article.slug %}">{{ article.title }}</a>
+                            {% endif %}
                         </li>
                     {% endfor %}
                 {% endif %}
@@ -254,9 +369,47 @@
                     <li class="dropdown-header">Related</li>
                     {% for article in related_articles %}
                         <li {% if page.slug == article.slug %}class="highlight"{% endif %}>
-                            <a href="{% url 'wiki:page_detail' article.slug %}">{{ article.title }}</a>
+                            {% if article.page_type == 'group' %}
+                                <a href="{% url 'wiki:group_detail' article.slug %}">{{ article.title }}</a>
+                            {% elif article.page_type == 'plot' %}
+                                <a href="{% url 'wiki:plot_detail' article.slug %}">{{ article.title }}</a>
+                            {% else %}
+                                <a href="{% url 'wiki:page_detail' article.slug %}">{{ article.title }}</a>
+                            {% endif %}
                         </li>
                     {% endfor %}
+                {% endif %}
+                
+                {% if user.is_staff or user.is_authenticated and page and can_edit %}
+                <li class="dropdown-divider"><hr/></li>
+                <li class="dropdown-header">Admin</li>
+                <li><a href="{% url 'wiki:page_list' %}">Wiki Home</a></li>
+                
+                {% if page %}
+                    {% if user.is_staff %}
+                    <li><a href="/admin/wiki/wikipage/{{ page.id }}/change/">Edit This Page</a></li>
+                    {% elif can_edit %}
+                        {% if page.page_type == 'group' %}
+                        <li><a href="{% url 'wiki:edit_group' page.slug %}">Edit This Page</a></li>
+                        {% elif page.page_type == 'plot' %}
+                        <li><a href="{% url 'wiki:edit_plot' page.slug %}">Edit This Page</a></li>
+                        {% else %}
+                        <li><a href="{% url 'wiki:edit_page' page.slug %}">Edit This Page</a></li>
+                        {% endif %}
+                    {% endif %}
+                    <li><a href="{% url 'wiki:page_history' page.slug %}">View History</a></li>
+                {% endif %}
+                
+                {% if user.is_authenticated %}
+                    {% if user.is_staff %}
+                    <li><a href="/admin/wiki/wikipage/add/?page_type=regular">Create Regular Page</a></li>
+                    <li><a href="/admin/wiki/wikipage/add/?page_type=group">Create Group Page</a></li>
+                    <li><a href="/admin/wiki/wikipage/add/?page_type=plot">Create Plot Page</a></li>
+                    {% else %}
+                    <li><a href="{% url 'wiki:create_group' %}">Create Group Page</a></li>
+                    <li><a href="{% url 'wiki:create_plot' %}">Create Plot Page</a></li>
+                    {% endif %}
+                {% endif %}
                 {% endif %}
                 
                 <li><a href="/channels/">Channels</a></li>
@@ -269,6 +422,9 @@
                     <li><a href="/characters/create/">Create Character</a></li>
                     <li><a href="/characters/">Manage Characters</a></li>
                     <li><a href="/accounts/profile/">Profile</a></li>
+                    {% if user.is_staff %}
+                    <li><a href="/admin/">Admin Panel</a></li>
+                    {% endif %}
                     <li><a href="/accounts/password_change/">Change Password</a></li>
                     <li><a href="/auth/logout/?next=/">Logout</a></li>
                 {% else %}

--- a/wiki/templates/wiki/create_page.html
+++ b/wiki/templates/wiki/create_page.html
@@ -1,0 +1,114 @@
+{% extends "wiki/base_wiki.html" %}
+{% load static %}
+
+{% block titleblock %}Create {{ page_type_name }} Page{% endblock %}
+
+{% block content %}
+<div class="creation-form-container">
+    <h1>Create New {{ page_type_name }} Page</h1>
+
+    <form method="post" enctype="multipart/form-data">
+        {% csrf_token %}
+        
+        <div class="form-group">
+            <label for="title">Title:</label>
+            <input type="text" class="form-control" id="title" name="title" required>
+        </div>
+        
+        {% if page_type == 'group' or page_type == 'plot' %}
+        <div class="form-group">
+            <label for="brief_description">Brief Description (appears on index page):</label>
+            <input type="text" class="form-control" id="brief_description" name="brief_description" maxlength="255">
+            <small class="form-text text-muted">
+                A short description (255 chars max) that will appear on the index listing.
+            </small>
+        </div>
+        {% endif %}
+        
+        <div class="form-group">
+            <label for="content">Content:</label>
+            <textarea class="form-control markdown-editor" id="content" name="content" rows="15"></textarea>
+            <small class="form-text text-muted">
+                You can use Markdown formatting for rich text. HTML is also supported.
+            </small>
+        </div>
+        
+        <div class="image-upload-section">
+            <h3>Page Images</h3>
+            
+            <div class="form-group">
+                <label for="featured_image">Featured Background Image:</label>
+                <input type="file" class="form-control" id="featured_image" name="featured_image" accept="image/*">
+                <small class="form-text text-muted">
+                    This image will appear as the background for your page header.
+                </small>
+            </div>
+            
+            <div class="form-group">
+                <label for="banner_image">Banner Image:</label>
+                <input type="file" class="form-control" id="banner_image" name="banner_image" accept="image/*">
+                <small class="form-text text-muted">
+                    This image will appear in the banner area of your page.
+                </small>
+            </div>
+            
+            <div class="form-group">
+                <label>
+                    <input type="checkbox" name="show_texture" checked> 
+                    Show texture overlay on featured image
+                </label>
+                <small class="form-text text-muted">
+                    The texture helps text remain readable over background images.
+                </small>
+            </div>
+        </div>
+        
+        <button type="submit" class="btn btn-primary mt-3">Create Page</button>
+    </form>
+</div>
+{% endblock %}
+
+{% block sidebar %}
+<div class="sidebar">
+    <h2>Quick Links</h2>
+    <ul>
+        {% if page_type == 'group' %}
+            <li><a href="{% url 'wiki:groups_index' %}">Back to Groups</a></li>
+        {% elif page_type == 'plot' %}
+            <li><a href="{% url 'wiki:plots_index' %}">Back to Plots</a></li>
+        {% else %}
+            <li><a href="{% url 'wiki:page_list' %}">Back to Wiki</a></li>
+        {% endif %}
+    </ul>
+    
+    <h2>Formatting Help</h2>
+    <ul>
+        <li>**Bold text** for <strong>bold text</strong></li>
+        <li>*Italic text* for <em>italic text</em></li>
+        <li># Heading 1</li>
+        <li>## Heading 2</li>
+        <li>- Bullet point</li>
+        <li>1. Numbered list</li>
+        <li>[Link text](URL) for links</li>
+        <li>&lt;img src="URL"&gt; for images</li>
+    </ul>
+</div>
+{% endblock %}
+
+{% block extrajs %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    // Initialize markdown editor if available
+    if (typeof SimpleMDE !== 'undefined') {
+        var simplemde = new SimpleMDE({ 
+            element: document.getElementById("content"),
+            spellChecker: false,
+            autosave: {
+                enabled: true,
+                unique_id: "new_wiki_page",
+            }
+        });
+    }
+});
+</script>
+{% endblock %} 

--- a/wiki/templates/wiki/edit_page.html
+++ b/wiki/templates/wiki/edit_page.html
@@ -1,0 +1,139 @@
+{% extends "wiki/base_edit.html" %}
+{% load static %}
+
+{% block titleblock %}Edit {{ page.title }}{% endblock %}
+
+{% block content %}
+<div class="creation-form-container">
+    <h1>Edit: {{ page.title }}</h1>
+
+    <form method="post" enctype="multipart/form-data">
+        {% csrf_token %}
+        
+        {% if page.page_type == 'group' or page.page_type == 'plot' %}
+        <div class="form-group">
+            <label for="brief_description">Brief Description (appears on index page):</label>
+            <input type="text" class="form-control" id="brief_description" name="brief_description" maxlength="255" value="{{ page.brief_description }}">
+            <small class="form-text text-muted">
+                A short description (255 chars max) that will appear on the index listing.
+            </small>
+        </div>
+        {% endif %}
+        
+        <div class="form-group">
+            <label for="content">Content:</label>
+            <textarea class="form-control markdown-editor" id="content" name="content" rows="15">{{ page.content }}</textarea>
+            <small class="form-text text-muted">
+                You can use Markdown formatting for rich text. HTML is also supported.
+            </small>
+        </div>
+        
+        <div class="image-upload-section">
+            <h3>Page Images</h3>
+            
+            <div class="form-group">
+                <label for="featured_image">Featured Background Image:</label>
+                <input type="file" class="form-control" id="featured_image" name="featured_image" accept="image/*">
+                {% if featured_image and featured_image.image %}
+                <div class="current-image">
+                    <p>Current image: <a href="{{ featured_image.get_image_url }}" target="_blank">View</a></p>
+                    <img src="{{ featured_image.get_image_url }}" style="max-width: 150px; max-height: 100px; margin-top: 5px;">
+                </div>
+                {% endif %}
+                <small class="form-text text-muted">
+                    This image will appear as the background for your page header.
+                </small>
+            </div>
+            
+            <div class="form-group">
+                <label for="banner_image">Banner Image:</label>
+                <input type="file" class="form-control" id="banner_image" name="banner_image" accept="image/*">
+                {% if featured_image and featured_image.banner %}
+                <div class="current-image">
+                    <p>Current image: <a href="{{ featured_image.get_banner_url }}" target="_blank">View</a></p>
+                    <img src="{{ featured_image.get_banner_url }}" style="max-width: 150px; max-height: 100px; margin-top: 5px;">
+                </div>
+                {% endif %}
+                <small class="form-text text-muted">
+                    This image will appear in the banner area of your page.
+                </small>
+            </div>
+            
+            <div class="form-group">
+                <label>
+                    <input type="checkbox" name="show_texture" {% if not featured_image or featured_image.show_texture %}checked{% endif %}> 
+                    Show texture overlay on featured image
+                </label>
+                <small class="form-text text-muted">
+                    The texture helps text remain readable over background images.
+                </small>
+            </div>
+        </div>
+        
+        <div class="form-group">
+            <label for="comment">Edit Comment:</label>
+            <input type="text" class="form-control" id="comment" name="comment" placeholder="Brief description of your changes">
+            <small class="form-text text-muted">
+                This helps others understand what you changed and why.
+            </small>
+        </div>
+        
+        <button type="submit" class="btn btn-primary mt-3">Save Changes</button>
+        {% if return_to == 'group' or page.page_type == 'group' %}
+            <a href="{% url 'wiki:group_detail' page.slug %}" class="btn btn-secondary mt-3">Cancel</a>
+        {% elif return_to == 'plot' or page.page_type == 'plot' %}
+            <a href="{% url 'wiki:plot_detail' page.slug %}" class="btn btn-secondary mt-3">Cancel</a>
+        {% else %}
+            <a href="{% url 'wiki:page_detail' page.slug %}" class="btn btn-secondary mt-3">Cancel</a>
+        {% endif %}
+    </form>
+</div>
+{% endblock %}
+
+{% block sidebar %}
+<div class="sidebar">
+    <h2>Quick Links</h2>
+    <ul>
+        {% if return_to == 'group' or page.page_type == 'group' %}
+            <li><a href="{% url 'wiki:group_detail' page.slug %}">Back to Page</a></li>
+            <li><a href="{% url 'wiki:groups_index' %}">All Groups</a></li>
+        {% elif return_to == 'plot' or page.page_type == 'plot' %}
+            <li><a href="{% url 'wiki:plot_detail' page.slug %}">Back to Page</a></li>
+            <li><a href="{% url 'wiki:plots_index' %}">All Plots</a></li>
+        {% else %}
+            <li><a href="{% url 'wiki:page_detail' page.slug %}">Back to Page</a></li>
+        {% endif %}
+        <li><a href="{% url 'wiki:page_history' page.slug %}">View History</a></li>
+    </ul>
+    
+    <h2>Formatting Help</h2>
+    <ul>
+        <li>**Bold text** for <strong>bold text</strong></li>
+        <li>*Italic text* for <em>italic text</em></li>
+        <li># Heading 1</li>
+        <li>## Heading 2</li>
+        <li>- Bullet point</li>
+        <li>1. Numbered list</li>
+        <li>[Link text](URL) for links</li>
+        <li>&lt;img src="URL"&gt; for images</li>
+    </ul>
+</div>
+{% endblock %}
+
+{% block extrajs %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    // Initialize markdown editor if available
+    if (typeof SimpleMDE !== 'undefined') {
+        var simplemde = new SimpleMDE({ 
+            element: document.getElementById("content"),
+            spellChecker: false,
+            autosave: {
+                enabled: true,
+                unique_id: "edit_wiki_{{ page.slug }}",
+            }
+        });
+    }
+});
+</script>
+{% endblock %} 

--- a/wiki/templates/wiki/group_detail.html
+++ b/wiki/templates/wiki/group_detail.html
@@ -1,0 +1,85 @@
+{% extends "wiki/base_wiki.html" %}
+{% load static %}
+
+{% block titleblock %}{{ page.title }}{% endblock %}
+
+{% block content %}
+<div class="left_content">
+    <h1>{{ page.title }}</h1>
+    
+    {% if page.mush_group %}
+    <div class="mush-group-info">
+        <div class="group-header">
+            <h2>Group Information</h2>
+            {% if page.mush_group.group_id %}
+            <span class="group-id">ID: {{ page.mush_group.group_id }}</span>
+            {% endif %}
+        </div>
+        
+        {% if page.mush_group.leader %}
+        <div class="group-detail">
+            <strong>Leader:</strong> {{ page.mush_group.leader.full_name }}
+        </div>
+        {% endif %}
+        
+        {% if page.mush_group.ic_description %}
+        <div class="group-detail">
+            <h3>IC Description</h3>
+            <div class="ic-description">
+                {{ page.mush_group.ic_description|linebreaksbr }}
+            </div>
+        </div>
+        {% endif %}
+        
+        {% if page.mush_group.roster %}
+        <div class="group-detail">
+            <strong>Roster:</strong> {{ page.mush_group.roster.name }}
+        </div>
+        {% endif %}
+        
+        {% if page.mush_group.website %}
+        <div class="group-detail">
+            <strong>Website:</strong> <a href="{{ page.mush_group.website }}" target="_blank">{{ page.mush_group.website }}</a>
+        </div>
+        {% endif %}
+        
+        <div class="group-members">
+            <h3>Members</h3>
+            <ul class="member-list">
+            {% for membership in page.mush_group.groupmembership_set.all %}
+                <li>
+                    {{ membership.character.full_name }}
+                    {% if membership.title %}<span class="member-title">{{ membership.title }}</span>{% endif %}
+                    {% if membership.role %}<span class="member-role">{{ membership.role.name }}</span>{% endif %}
+                </li>
+            {% empty %}
+                <li><em>No members listed</em></li>
+            {% endfor %}
+            </ul>
+        </div>
+        
+        <hr class="group-separator" />
+    </div>
+    {% endif %}
+    
+    {{ page.content|safe }}
+</div>
+
+<div class="right_content {% if not page.right_content %}hidden{% endif %}">
+    {% if page.right_content %}
+        {{ page.right_content|safe }}
+    {% endif %}
+    
+    {% if page.mush_group %}
+    <div class="sidebar-section">
+        <h4>Group Actions</h4>
+        <ul>
+            {% if user.is_authenticated %}
+            <li><a href="/groups/view/{{ page.mush_group.group_id }}/">View in Group System</a></li>
+            <li><a href="/groups/join/{{ page.mush_group.group_id }}/">Request to Join</a></li>
+            {% endif %}
+        </ul>
+    </div>
+    {% endif %}
+</div>
+{% endblock %} 

--- a/wiki/templates/wiki/groups_index.html
+++ b/wiki/templates/wiki/groups_index.html
@@ -1,0 +1,42 @@
+{% extends "wiki/base_wiki.html" %}
+{% load static %}
+{% load wiki_filters %}
+
+{% block titleblock %}Group Pages{% endblock %}
+
+{% block content %}
+<div class="content-header">
+    <h1>Group Pages</h1>
+    <p>This section contains pages for player-created groups like werewolf packs, vampire covens, mage cabals, and player-run businesses.</p>
+    
+    <div class="header-actions">
+        {% if can_create %}
+        <a href="{% url 'wiki:create_group' %}" class="btn">Create New Group Page</a>
+        {% endif %}
+        <a href="{% url 'wiki:plots_index' %}" class="btn">View Plots</a>
+        <a href="{% url 'wiki:page_list' %}" class="btn">All Wiki Pages</a>
+    </div>
+</div>
+
+<div class="wiki-pages full-width">
+    {% if groups %}
+        <div class="list-group">
+        {% for page in groups %}
+            <a href="{% url 'wiki:group_detail' page.slug %}" class="list-group-item list-group-item-action">
+                <h5 class="mb-1">{{ page.title }}</h5>
+                {% if page.brief_description %}
+                <div class="brief-description">{{ page.brief_description }}</div>
+                {% endif %}
+                <small>Last edited by {{ page.last_editor|display_username }} on {{ page.updated_at|date }}</small>
+            </a>
+        {% endfor %}
+        </div>
+    {% else %}
+        <p>No group pages have been created yet.</p>
+    {% endif %}
+</div>
+{% endblock %}
+
+{% block sidebar %}
+<!-- Empty sidebar to ensure all content is in the main column -->
+{% endblock %} 

--- a/wiki/templates/wiki/page_list.html
+++ b/wiki/templates/wiki/page_list.html
@@ -2,12 +2,11 @@
 {% load static %}
 {% load wiki_filters %}
 
-{% block titleblock %}Wiki Pages{% endblock %}
+{% block titleblock %}Dies Irae Wiki{% endblock %}
 
 {% block content %}
-<h1>Wiki Pages</h1>
 {% if pages %}
-    <div class="list-group">
+    <div class="list-group wiki-pages">
     {% for page in pages %}
         <a href="{% url 'wiki:page_detail' page.slug %}" class="list-group-item list-group-item-action">
             <h5 class="mb-1">{{ page.title }}</h5>
@@ -25,9 +24,14 @@
     <h2>Quick Links</h2>
     <ul>
         {% if user.is_staff %}
-        <li><a href="/admin/wiki/wikipage/add/">Create New Page</a></li>
+        <li><a href="{% url 'wiki:create_page' %}">Create Regular Page</a></li>
         {% endif %}
-        <li><a href="{% url 'wiki:page_list' %}">All Pages</a></li>
+        {% if user.is_authenticated %}
+        <li><a href="{% url 'wiki:create_group' %}">Create Group Page</a></li>
+        <li><a href="{% url 'wiki:create_plot' %}">Create Plot Page</a></li>
+        {% endif %}
+        <li><a href="{% url 'wiki:groups_index' %}">Groups</a></li>
+        <li><a href="{% url 'wiki:plots_index' %}">Plots</a></li>
     </ul>
 </div>
 {% endblock %}

--- a/wiki/templates/wiki/player_edit.html
+++ b/wiki/templates/wiki/player_edit.html
@@ -1,0 +1,177 @@
+{% extends "wiki/base_edit.html" %}
+{% load static %}
+
+{% block titleblock %}Edit {{ page.title }}{% endblock %}
+
+{% block content %}
+<div class="creation-form-container">
+    <h1>Edit: {{ page.title }}</h1>
+
+    {% if messages %}
+    <div class="alert-container">
+        {% for message in messages %}
+        <div class="alert alert-{{ message.tags }}">
+            {{ message }}
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    <form method="post" enctype="multipart/form-data">
+        {% csrf_token %}
+        
+        <div class="form-group">
+            <label for="content">Content:</label>
+            <textarea class="form-control markdown-editor" id="content" name="content" rows="15">{{ page.content }}</textarea>
+            <small class="form-text text-muted">
+                You can use Markdown formatting for rich text. HTML is also supported.
+            </small>
+        </div>
+        
+        {% if can_upload_images %}
+        <div class="image-upload-section">
+            <h3>Page Images</h3>
+            
+            <div class="form-group">
+                <label for="featured_image">Featured Background Image:</label>
+                <input type="file" class="form-control" id="featured_image" name="featured_image" accept="image/*">
+                {% if featured_image and featured_image.image %}
+                <div class="current-image">
+                    <p>Current image: <a href="{{ featured_image.get_image_url }}" target="_blank">View</a></p>
+                    <img src="{{ featured_image.get_image_url }}" style="max-width: 150px; max-height: 100px; margin-top: 5px;">
+                </div>
+                {% endif %}
+                <small class="form-text text-muted">
+                    This image will appear as the background for your page header.
+                </small>
+            </div>
+        </div>
+        {% endif %}
+        
+        <div class="form-group">
+            <label for="comment">Edit Comment:</label>
+            <input type="text" class="form-control" id="comment" name="comment" placeholder="Brief description of your changes" required>
+            <small class="form-text text-muted">
+                Please explain what you changed and why. This helps keep track of page updates.
+            </small>
+        </div>
+        
+        <div class="actions">
+            <button type="submit" class="btn btn-primary mt-3">Save Changes</button>
+            
+            {% if return_to == 'group' or page.page_type == 'group' %}
+                <a href="{% url 'wiki:group_detail' page.slug %}" class="btn btn-secondary mt-3">Cancel</a>
+            {% elif return_to == 'plot' or page.page_type == 'plot' %}
+                <a href="{% url 'wiki:plot_detail' page.slug %}" class="btn btn-secondary mt-3">Cancel</a>
+            {% else %}
+                <a href="{% url 'wiki:page_detail' page.slug %}" class="btn btn-secondary mt-3">Cancel</a>
+            {% endif %}
+            
+            <div class="preview-container mt-3">
+                <button type="button" id="preview-button" class="btn btn-info">Preview Changes</button>
+                <div id="preview-area" class="content-preview" style="display: none; margin-top: 20px; padding: 15px; border: 1px solid #ccc;">
+                    <h3>Preview</h3>
+                    <div id="preview-content"></div>
+                </div>
+            </div>
+        </div>
+    </form>
+</div>
+{% endblock %}
+
+{% block sidebar %}
+<div class="sidebar">
+    <h2>Quick Links</h2>
+    <ul>
+        {% if return_to == 'group' or page.page_type == 'group' %}
+            <li><a href="{% url 'wiki:group_detail' page.slug %}">Back to Page</a></li>
+            <li><a href="{% url 'wiki:groups_index' %}">All Groups</a></li>
+        {% elif return_to == 'plot' or page.page_type == 'plot' %}
+            <li><a href="{% url 'wiki:plot_detail' page.slug %}">Back to Page</a></li>
+            <li><a href="{% url 'wiki:plots_index' %}">All Plots</a></li>
+        {% else %}
+            <li><a href="{% url 'wiki:page_detail' page.slug %}">Back to Page</a></li>
+        {% endif %}
+        <li><a href="{% url 'wiki:page_history' page.slug %}">View History</a></li>
+    </ul>
+    
+    <h2>Editing Guidelines</h2>
+    <ul>
+        <li>Keep content factual and relevant</li>
+        <li>Respect existing information</li>
+        <li>Use appropriate language</li>
+        <li>Cite sources when possible</li>
+    </ul>
+    
+    <h2>Formatting Help</h2>
+    <ul>
+        <li>**Bold text** for <strong>bold text</strong></li>
+        <li>*Italic text* for <em>italic text</em></li>
+        <li># Heading 1</li>
+        <li>## Heading 2</li>
+        <li>- Bullet point</li>
+        <li>1. Numbered list</li>
+        <li>[Link text](URL) for links</li>
+        <li>&lt;img src="URL"&gt; for images</li>
+    </ul>
+</div>
+{% endblock %}
+
+{% block extrajs %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    // Initialize markdown editor if available
+    if (typeof SimpleMDE !== 'undefined') {
+        var simplemde = new SimpleMDE({ 
+            element: document.getElementById("content"),
+            spellChecker: false,
+            autosave: {
+                enabled: true,
+                unique_id: "edit_wiki_{{ page.slug }}",
+            }
+        });
+    }
+    
+    // Preview functionality
+    document.getElementById('preview-button').addEventListener('click', function() {
+        let content;
+        if (typeof simplemde !== 'undefined') {
+            content = simplemde.value();
+        } else {
+            content = document.getElementById('content').value;
+        }
+        
+        const previewArea = document.getElementById('preview-area');
+        const previewContent = document.getElementById('preview-content');
+        
+        // Toggle preview display
+        if (previewArea.style.display === 'none') {
+            fetch('{% url "wiki:preview" %}', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value
+                },
+                body: new URLSearchParams({
+                    'content': content
+                })
+            })
+            .then(response => response.json())
+            .then(data => {
+                previewContent.innerHTML = data.html;
+                previewArea.style.display = 'block';
+                this.textContent = 'Hide Preview';
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                previewContent.innerHTML = '<p>Error generating preview</p>';
+                previewArea.style.display = 'block';
+            });
+        } else {
+            previewArea.style.display = 'none';
+            this.textContent = 'Preview Changes';
+        }
+    });
+});
+</script>
+{% endblock %} 

--- a/wiki/templates/wiki/plots_index.html
+++ b/wiki/templates/wiki/plots_index.html
@@ -1,0 +1,42 @@
+{% extends "wiki/base_wiki.html" %}
+{% load static %}
+{% load wiki_filters %}
+
+{% block titleblock %}Plot Pages{% endblock %}
+
+{% block content %}
+<div class="content-header">
+    <h1>Plot Pages</h1>
+    <p>This section contains pages for player-run stories and collaborative plots between players and staff.</p>
+    
+    <div class="header-actions">
+        {% if can_create %}
+        <a href="{% url 'wiki:create_plot' %}" class="btn">Create New Plot Page</a>
+        {% endif %}
+        <a href="{% url 'wiki:groups_index' %}" class="btn">View Groups</a>
+        <a href="{% url 'wiki:page_list' %}" class="btn">All Wiki Pages</a>
+    </div>
+</div>
+
+<div class="wiki-pages full-width">
+    {% if plots %}
+        <div class="list-group">
+        {% for page in plots %}
+            <a href="{% url 'wiki:plot_detail' page.slug %}" class="list-group-item list-group-item-action">
+                <h5 class="mb-1">{{ page.title }}</h5>
+                {% if page.brief_description %}
+                <div class="brief-description">{{ page.brief_description }}</div>
+                {% endif %}
+                <small>Last edited by {{ page.last_editor|display_username }} on {{ page.updated_at|date }}</small>
+            </a>
+        {% endfor %}
+        </div>
+    {% else %}
+        <p>No plot pages have been created yet.</p>
+    {% endif %}
+</div>
+{% endblock %}
+
+{% block sidebar %}
+<!-- Empty sidebar to ensure all content is in the main column -->
+{% endblock %} 

--- a/wiki/urls.py
+++ b/wiki/urls.py
@@ -6,6 +6,27 @@ app_name = 'wiki'
 urlpatterns = [
     path('', views.page_list, name='page_list'),
     path('search/', views.search_wiki, name='search'),
+    
+    # Group pages
+    path('groups/', views.groups_index, name='groups_index'),
+    path('groups/create/', views.create_group, name='create_group'),
+    path('groups/<slug:slug>/', views.group_detail, name='group_detail'),
+    path('groups/<slug:slug>/edit/', views.edit_group, name='edit_group'),
+    
+    # Plot pages
+    path('plots/', views.plots_index, name='plots_index'),
+    path('plots/create/', views.create_plot, name='create_plot'),
+    path('plots/<slug:slug>/', views.plot_detail, name='plot_detail'),
+    path('plots/<slug:slug>/edit/', views.edit_plot, name='edit_plot'),
+    
+    # Edit pages
+    path('create/', views.create_page, name='create_page'),
+    path('<slug:slug>/edit/', views.edit_page, name='edit_page'),
+    
+    # Preview functionality
+    path('preview/', views.preview_markdown, name='preview'),
+    
+    # Default page views - these should be last as they're most general
     path('<slug:slug>/', views.page_detail, name='page_detail'),
     path('<slug:slug>/history/', views.page_history, name='page_history'),
 ]

--- a/world/wod20th/utils/mortalplus_utils.py
+++ b/world/wod20th/utils/mortalplus_utils.py
@@ -145,6 +145,8 @@ def initialize_mortalplus_stats(character, mortalplus_type):
         # Set blood pool
         character.set_stat('pools', 'dual', 'Blood', 3, temp=False)
         character.set_stat('pools', 'dual', 'Blood', 3, temp=True)
+        character.set_stat('pools', 'dual', 'Willpower', 3, temp=False)
+        character.set_stat('pools', 'dual', 'Willpower', 3, temp=True)
         
     elif mortalplus_type == 'Kinain':
         # Initialize arts and realms categories
@@ -164,22 +166,36 @@ def initialize_mortalplus_stats(character, mortalplus_type):
         character.set_stat('identity', 'lineage', 'Second Legacy', '', temp=True)
         character.set_stat('identity', 'lineage', 'Affinity Realm', '', temp=False)
         character.set_stat('identity', 'lineage', 'Affinity Realm', '', temp=True)
+
+        character.set_stat('pools', 'dual', 'Willpower', 3, temp=False)
+        character.set_stat('pools', 'dual', 'Willpower', 3, temp=True)
         
     elif mortalplus_type == 'Sorcerer':
         # Additional sorcerer-specific initializations, if any
-        pass
+        character.set_stat('pools', 'dual', 'Willpower', 5, temp=False)
+        character.set_stat('pools', 'dual', 'Willpower', 5, temp=True)
         
     elif mortalplus_type == 'Psychic':
         # Additional psychic-specific initializations, if any
-        pass
+        character.set_stat('pools', 'dual', 'Willpower', 5, temp=False)
+        character.set_stat('pools', 'dual', 'Willpower', 5, temp=True)
         
     elif mortalplus_type == 'Faithful':
         # Initialize faith category
         character.db.stats['powers']['faith'] = {}
-        
-    # Set base Willpower
-    character.set_stat('pools', 'dual', 'Willpower', 3, temp=False)
-    character.set_stat('pools', 'dual', 'Willpower', 3, temp=True)
+        character.set_stat('pools', 'dual', 'Willpower', 5, temp=False)
+        character.set_stat('pools', 'dual', 'Willpower', 5, temp=True)
+    
+    elif mortalplus_type == 'Kinfolk':
+        # Initialize tribe category
+        character.db.stats['identity']['lineage']['Tribe'] = ''
+        character.db.stats['identity']['lineage']['Pack'] = ''
+        character.db.stats['identity']['lineage']['Patron Totem'] = ''
+        character.db.stats['identity']['lineage']['Kinfolk Breed'] = ''
+        character.db.stats['powers']['gift'] = {}
+        character.db.stats['powers']['rite'] = {}
+        character.set_stat('pools', 'dual', 'Willpower', 3, temp=False)
+        character.set_stat('pools', 'dual', 'Willpower', 3, temp=True)
 
 def initialize_ghoul_stats(character):
     """Initialize Ghoul-specific stats."""

--- a/world/wod20th/utils/shifter_utils.py
+++ b/world/wod20th/utils/shifter_utils.py
@@ -57,7 +57,7 @@ AUSPICE_CHOICES_DICT: Dict[str, List[str]] = {
 ASPECT_CHOICES_DICT: Dict[str, List[str]] = {
     'Ajaba': ['Dawn', 'Midnight', 'Dusk'],
     'Ananasi': ['Tenere', 'Hatar', 'Kumo', 'Kumoti', 'Antara', 'Kumatai', 'Padrone'],
-    'Ratkin': ['Knife Skulkers', 'Shadow Seers', 'Tunnel Runners', 'Warriors'],
+    'Ratkin': ['Knife Skulkers', 'Shadow Seers', 'Tunnel Runners', 'Warriors', 'Plague Lords', 'Engineers', 'Munchmausen', 'Twitchers'],
     'Mokole': ['Rising Sun', 'Noonday Sun', 'Shrouded Sun', 'Midnight Sun', 
                'Decorated Sun', 'Solar Eclipse']
 }

--- a/world/wod20th/utils/xp_costs.py
+++ b/world/wod20th/utils/xp_costs.py
@@ -497,12 +497,18 @@ def calculate_sorcerous_path_cost(current_rating: int, new_rating: int) -> int:
         
     Returns:
         int: Total XP cost
-        
+        New paths are 10xp, then 5xp * rating.
     Example:
-        7XP for rating 1, 14XP for rating 2, 21XP for rating 3, etc.
+        10XP for rating 1, 15XP for rating 2, 20XP for rating 3, etc.
     """
     # Sorcery uses new_rating for calculation (non-standard)
-    return new_rating * 7
+    total_cost = 0
+    if current_rating == 0:
+        total_cost = 10
+        current_rating = 1
+    for rating in range(current_rating, new_rating):
+        total_cost += rating * 5
+    return total_cost
 
 def calculate_arcanos_cost(current_rating: int, new_rating: int) -> int:
     """

--- a/world/wod20th/utils/xp_utils.py
+++ b/world/wod20th/utils/xp_utils.py
@@ -335,6 +335,285 @@ SHIFTER_MAPPINGS = {
         }
     }
 }
+GENERAL_SHIFTER_GIFTS = {
+    'Ajaba': [
+        'Eye of the Hunter',
+        'Wolf at the Door',
+        'Infectious Laughter',
+        'Primal Anger',
+        'Sense Prey',
+        'Curse of Hatred',
+        "Man's Skin",
+        'Odious Aroma',
+        'Pulse of the Prey',
+        'Clenched Jaw',
+        'Gift of the Skunk', 
+        'Laugh of the Hyena',
+        'Crushing Jaws',
+        'Feral Grin',
+        'Laughter of the Soul',
+        'Culling the Weak',
+        'Gnaw',
+        'Gorge',
+        'Endurance of Heimdall',
+        'Survivor',
+        'Withering Stare'
+    ],
+    'Ananasi': [
+        'Balance',
+        'Spirit of the Lizard',
+        'Many Eyes',
+        'Resist Pain',
+        'Resist Toxin',
+        'Stolen Moments',
+        'Hand Fangs',
+        'Man-Spider Form',
+        'Replenishment of the Flesh',
+        'Gift of the Porcupine',
+        'Blood Pump',
+        'Great Leap',
+        'Catfeet',
+        'Entropic Bite',
+        'Hydraulic Strength',
+        'Carapace',
+        'Survivor'
+    ],
+    'Bastet': [
+        'Banish Sickness',
+        'Catfeet',
+        'Razor Claws',
+        "Mother's Touch",
+        'Open Seal',
+        'Sense Magic',
+        'Truth of Gaia',
+        'Sense Wyrm',
+        'Silent Stalking',
+        'Eyes of the Cat',
+        'Staredown',
+        'Spirit of the Fray',
+        "Night's Passage",
+        'Pulse of the Prey',
+        'Sense Silver',
+        'Shriek',
+        'Taking the Forgotten',
+        'Caper',
+        'Scrying',
+        "Impala's Flight",
+        'Invisibility',
+        'Mental Speech',
+        'Clawstorm',
+        'Walking Between Worlds',
+        'Silver Claws',
+        'Perfect Passage',
+        'Withering Stare'
+    ],
+    'Corax': [
+        'Enemy Ways',
+        'Morse',
+        'Open Seal',
+        'Persuasion', 
+        "Raven's Gleaning",
+        "Scent of the True Form",
+        'Spirit Speech',
+        'Truth of Gaia',
+        'Voice of the Mimic',
+        'Carrion\'s Call',
+        'Messenger\'s Fortitude',
+        'Razor Feathers',
+        'Sky\'s Beneficence',
+        'Speech of the World',
+        'Swallow\'s Return',
+        'Taking the Forgotten',
+        'Whisper Catching',
+        'Spider\'s Song',
+        'Dead Talk',
+        'Eyes of the Eagle',
+        'Hummingbird Dart',
+        'Mynah\'s Touch',
+        'Scrying',
+        'Sense the Unnatural',
+        'Sun\'s Guard',
+        'Attunement',
+        'Airt Sense Gift',
+        'Bloody Feather Storm',
+        'Flight of Separation',
+        'Gauntlet Runner',
+        'Kiss of Helios',
+        'Deceptive Demise',
+        'Portents',
+        'Theft of Stars',
+        'Thieving Talons of the Magpie'
+    ],
+    'Gurahl': [
+        'Desperate Strength',
+        "Mother's Touch",
+        'Resist Pain',
+        'Nature\'s Plenty',
+        'Sense Wyrm',
+        'Danger Sense Gift',
+        'Resist Toxin',
+        'Wyld Resurgence',
+        'Calm',
+        'True Fear',
+        'Para Bellum',
+        'Treeshake',
+        'Calm the Savage Beast',
+        'Dreams fo the Buri-Jaan',
+        'Lover\'s Touch',
+        'Adaptation',
+        'Heart of the Mountain',
+        'Bury the Wolf',
+        'Masking the Hunted',
+        'Gaia\'s Breath',
+        'Gentle Soul'
+
+    ],
+    'Kitsune': [
+        'Chi Sense',
+        'Mindspeak',
+        'Scent of Running Water',
+        'Moon Dance',
+        'Sense Magic',
+        'Spirit Speech',
+        'Ghost Speech',
+        'Puppeteer\'s Secret',
+        'Shadow-Fan-Flowers',
+        'Possession'
+    ],
+    'Mokole': [
+        'Falling Touch',
+        'Fatal Flaw', 
+        'Inspiration',
+        'Razor Claws',
+        'Sense Wyrm',
+        'Shed', 
+        'Scent of the True Form',
+        'Speed of Thought',
+        'Blessings of the Nest',
+        'Reptoid Form',
+        'Sense Silver',
+        'Silver Claws',
+        'Odious Aroma',
+        'True Fear',
+        'Dragon\'s Breath',
+        'Walking Between Worlds',
+        'Attunement',
+        'Cocoon',
+        'Serenity',
+        'Grasp the Beyond',
+        'Song of the Great Beast'
+    ],
+    'Nagah': [
+        'Eyes of the Dragon Kings',
+        'Lizard\'s Favor',
+        'Scent of Running Water',
+        'Sense Wyrm',
+        'Fatal Flaw',
+        'Shed', 
+        'Burrow',
+        'Mindspeak',
+        'Pulse of the Prey',
+        'Veil of the Wani',
+        'Blessings of Kali', 
+        'Combat Healing', 
+        'Pure Venom',
+        'Darting Fangs',
+        'Swimming the Spirit River',
+        'Breath of the Dragon Lords'
+    ],
+    'Nuwisha': [
+        'Camouflage',
+        "Coyote's Intuition",
+        'Earworm',
+        'Emperor\'s Clothes',
+        'Finders Keepers',
+        'Laugh of the Hyena',
+        'Speed of Thought',
+        'Salaryman',
+        'Scent of Sweet Honey',
+        'Secret Question',
+        'Sleep of the Ages',
+        'Shed',
+        'Spirit Speech',
+        'Swollen Tongue',
+        'Man\'s Skin',
+        'Two Tongues',
+        'Beneath the Electron Bridge',
+        'Command Spirit',
+        'Curse of Tiresias',
+        'Distractions',
+        'Gift of the Termite',
+        'New Face',
+        'Odious Aroma',
+        'Spirit of the Fish',
+        'Sheep\'s Clothing',
+        'Suspicious Glance',
+        'Tiny Coyote',
+        'Voice Bank',
+        'Blisters',
+        'False Spoor',
+        'Fool\'s Fortune',
+        'Forbidden Words',
+        'Gift of Rage',
+        'Happy Thoughts',
+        'Now You Don\'t', 
+        'Pain Remains',
+        'Spirit of the Bird',
+        'Shadow Walk',
+        'Umbral Camouflage',
+        'Pulse of the Invisible',
+        'Bridge Walker',
+        'Cartoon Physics',
+        'Disappearing Act',
+        'Grasp the Beyond',
+        'Locked Door',
+        'Phantasm',
+        'Playing the Heart-Strings',
+        'Trickster\'s Skin',
+        'Assimilation',
+        'Fetish Doll',
+        'Ghost Danse',
+        'Friend and Foe',
+        'Stop Hitting Yourself',
+        'Ultimate Argument of Logic',
+        'Umbral Gateway'
+    ],
+    'Ratkin': [
+        'City Running',
+        'Cloak of Shadows',
+        'Darksight Gift',
+        'Spirit of the Lizard',
+        'Deep Pockets',
+        'Backbite',
+        'Squeeze',
+        'Attunement',
+        'Gnaw',
+        'Riot', 
+        'Survivor'
+    ],
+    'Rokea': [
+        'Hare\'s Leap',
+        'Fast',
+        'Killing Bite',
+        'Sense Danger',
+        'Gift of the Porcupine',
+        'Gulp', 
+        'Venom Blood',
+        'Scent of Sight',
+        'Troll Skin',
+        'Wyld Resurgence',
+        'Resist Toxin',
+        'Fathom Sight',
+        'Gift of the Ray',
+        'Rat Head',
+        'Form of Sea',
+        'Fenris\' Bite',
+        'Patient Hunter',
+        'Song of the Great Beast', 
+        'Primal Assurance',
+        'Whirlpool Maw'
+    ]   
+}
 
 def _get_primary_thaumaturgy_path(character):
     """Get the primary thaumaturgy path for a character. This is the first path purchased and the one that is the highest rating. 
@@ -464,6 +743,32 @@ def calculate_xp_cost(character, is_staff_spend: bool, stat_name: str, category:
         else:
             total_cost = calculate_ability_cost(current_rating, new_rating)
             requires_approval = new_rating > 2
+        return total_cost, requires_approval
+        
+    # Handle rites
+    elif category == 'powers' and subcategory == 'rite':
+        from world.wod20th.utils.xp_costs import calculate_rite_cost
+        # Get the rite level from the RITE_VALUES mapping
+        from world.wod20th.utils.stat_mappings import RITE_VALUES
+        
+        # Default to level 1 if we can't determine from RITE_VALUES
+        rite_level = 1
+        is_minor = False
+        
+        if stat_name in RITE_VALUES:
+            rite_values = RITE_VALUES[stat_name]
+            if rite_values and isinstance(rite_values, list):
+                rite_level = rite_values[0]  # Use the first value as the level
+            elif rite_values:
+                rite_level = rite_values
+                
+            # Check if it's a minor rite (level 0)
+            if rite_level == 0:
+                is_minor = True
+                
+        total_cost = calculate_rite_cost(rite_level, is_minor)
+        requires_approval = rite_level > 1
+        
         return total_cost, requires_approval
 
     # Handle disciplines
@@ -1135,6 +1440,101 @@ def _determine_stat_category(stat_name):
     """
     logger.log_info(f"Determining category for stat: {stat_name}")
 
+    # Import merit, flaw, and rite data structures for comprehensive checking
+    from world.wod20th.utils.stat_mappings import (
+        MERIT_VALUES, FLAW_VALUES, 
+        MERIT_CATEGORIES, FLAW_CATEGORIES,
+        ALL_MERITS, ALL_FLAWS, RITE_VALUES
+    )
+    
+    # Check for rites first - exact match only
+    stat_name_lower = stat_name.lower()
+    for rite_name in RITE_VALUES.keys():
+        if rite_name.lower() == stat_name_lower:
+            logger.log_info(f"Found exact rite match: {rite_name}")
+            return ('powers', 'rite')
+    
+    # Check for merit or flaw by direct lookup in values dictionaries
+    stat_name_lower = stat_name.lower()
+    
+    # Check if it's a merit using MERIT_VALUES - exact match only
+    for merit_name in MERIT_VALUES.keys():
+        if merit_name.lower() == stat_name_lower:
+            # Determine the merit category
+            for category, merits in MERIT_CATEGORIES.items():
+                if merit_name in merits:
+                    logger.log_info(f"Found exact merit match: {merit_name} in category {category}")
+                    return ('merits', category)
+    
+    # Check if it's a flaw using FLAW_VALUES - exact match only
+    for flaw_name in FLAW_VALUES.keys():
+        if flaw_name.lower() == stat_name_lower:
+            # Determine the flaw category
+            for category, flaws in FLAW_CATEGORIES.items():
+                if flaw_name in flaws:
+                    logger.log_info(f"Found exact flaw match: {flaw_name} in category {category}")
+                    return ('flaws', category)
+    
+    # Stricter fuzzy matching for merits - check for exact words
+    # Only consider it a match if the input is a complete multi-word match or very similar
+    if len(stat_name_lower.split()) > 1:  # Only do fuzzy matching for multi-word inputs
+        word_set = set(stat_name_lower.split())
+        close_merits = []
+        
+        for merit in ALL_MERITS:
+            if 'name' not in merit:
+                continue
+                
+            merit_name = merit['name']
+            merit_words = set(merit_name.lower().split())
+            
+            # Check if all words in stat_name are in the merit name
+            if word_set.issubset(merit_words) or merit_words.issubset(word_set):
+                # Only consider it a match if most words match
+                word_match_ratio = len(word_set.intersection(merit_words)) / max(len(word_set), len(merit_words))
+                if word_match_ratio > 0.7:  # At least 70% of words must match
+                    close_merits.append((merit, word_match_ratio))
+        
+        if close_merits:
+            best_match = max(close_merits, key=lambda x: x[1])[0]
+            merit_name = best_match['name']
+            merit_type = best_match.get('type', 'physical').lower()
+            
+            logger.log_info(f"Found strict fuzzy merit match: {merit_name} of type {merit_type}")
+            return ('merits', merit_type)
+    
+    # Stricter fuzzy matching for flaws - check for exact words
+    if len(stat_name_lower.split()) > 1:  # Only do fuzzy matching for multi-word inputs
+        word_set = set(stat_name_lower.split())
+        close_flaws = []
+        
+        for flaw in ALL_FLAWS:
+            if 'name' not in flaw:
+                continue
+                
+            flaw_name = flaw['name']
+            flaw_words = set(flaw_name.lower().split())
+            
+            # Check if all words in stat_name are in the flaw name
+            if word_set.issubset(flaw_words) or flaw_words.issubset(word_set):
+                # Only consider it a match if most words match
+                word_match_ratio = len(word_set.intersection(flaw_words)) / max(len(word_set), len(flaw_words))
+                if word_match_ratio > 0.7:  # At least 70% of words must match
+                    close_flaws.append((flaw, word_match_ratio))
+        
+        if close_flaws:
+            best_match = max(close_flaws, key=lambda x: x[1])[0]
+            flaw_name = best_match['name']
+            flaw_type = best_match.get('type', 'physical').lower()
+            
+            logger.log_info(f"Found strict fuzzy flaw match: {flaw_name} of type {flaw_type}")
+            return ('flaws', flaw_type)
+    
+    # Special case handling for very specific merit/flaw matches
+    if stat_name_lower == "acute sense" or stat_name_lower == "acute senses":
+        logger.log_info(f"Matched special case 'Acute Sense(s)': {stat_name}")
+        return ('merits', 'physical')
+
     # Check for rituals first - case insensitive
     stat_name_lower = stat_name.lower()
     
@@ -1166,10 +1566,19 @@ def _determine_stat_category(stat_name):
             return ('merits', merit_category)
         # Try case-insensitive match
         stat_lower = stat_name.lower()
-        for merit in merits:
-            if isinstance(merit, str) and merit.lower() == stat_lower:
-                logger.log_info(f"Found case-insensitive merit match: {merit}")
-                return ('merits', merit_category)
+        
+        # Check if merits is a dictionary or a list
+        if isinstance(merits, dict):
+            for merit_name in merits.keys():
+                if isinstance(merit_name, str) and merit_name.lower() == stat_lower:
+                    logger.log_info(f"Found case-insensitive merit match: {merit_name}")
+                    return ('merits', merit_category)
+        else:
+            # Assume it's a list-like structure
+            for merit in merits:
+                if isinstance(merit, str) and merit.lower() == stat_lower:
+                    logger.log_info(f"Found case-insensitive merit match: {merit}")
+                    return ('merits', merit_category)
 
     # Check if it's a flaw
     from world.wod20th.utils.stat_mappings import FLAW_VALUES
@@ -1180,10 +1589,19 @@ def _determine_stat_category(stat_name):
             return ('flaws', flaw_category)
         # Try case-insensitive match
         stat_lower = stat_name.lower()
-        for flaw in flaws:
-            if isinstance(flaw, str) and flaw.lower() == stat_lower:
-                logger.log_info(f"Found case-insensitive flaw match: {flaw}")
-                return ('flaws', flaw_category)
+        
+        # Check if flaws is a dictionary or a list
+        if isinstance(flaws, dict):
+            for flaw_name in flaws.keys():
+                if isinstance(flaw_name, str) and flaw_name.lower() == stat_lower:
+                    logger.log_info(f"Found case-insensitive flaw match: {flaw_name}")
+                    return ('flaws', flaw_category)
+        else:
+            # Assume it's a list-like structure
+            for flaw in flaws:
+                if isinstance(flaw, str) and flaw.lower() == stat_lower:
+                    logger.log_info(f"Found case-insensitive flaw match: {flaw}")
+                    return ('flaws', flaw_category)
 
     # Check if it's a background (case-insensitive)
     all_backgrounds = (UNIVERSAL_BACKGROUNDS + VAMPIRE_BACKGROUNDS + 
@@ -1562,12 +1980,25 @@ def calculate_gift_cost(character, gift_name, new_rating, current_rating=None):
         shifter_type = character.db.stats.get('identity', {}).get('lineage', {}).get('Type', {}).get('perm', '')
         logger.log_info(f"Calculating gift cost for {shifter_type} character")
 
-        # For Ajaba, get their aspect
+        # For shifters who have it, get their aspect
         aspect = None
-        if shifter_type == 'Ajaba':
+        if shifter_type in ['Ajaba', 'Ratkin', 'Ananasi']:
             aspect = character.db.stats.get('identity', {}).get('lineage', {}).get('Aspect', {}).get('perm', '')
-            logger.log_info(f"Ajaba character with aspect: {aspect}")
+            logger.log_info(f"Shifter character with aspect: {aspect}")
+        
+        if shifter_type in ['Ananasi']:
+            faction = character.db.stats.get('identity', {}).get('lineage', {}).get('Ananasi Faction', {}).get('perm', '')
+            logger.log_info(f"Ananasi character with faction: {faction}")
 
+        # Check if this is a general gift for this shifter type
+        if shifter_type and shifter_type != 'Garou' and gift_name in GENERAL_SHIFTER_GIFTS.get(shifter_type, []):
+            # Use in-breed cost (3 per level)
+            logger.log_info(f"Gift '{gift_name}' is a general gift for {shifter_type}. Using in-breed cost.")
+            return new_rating * 3
+        
+        # If we get here, it's not a general gift
+        logger.log_info(f"Gift '{gift_name}' is not a general gift for {shifter_type}. Using standard cost calculation.")
+    
         # Get the gift details from the database
         from world.wod20th.models import Stat
         from django.db.models import Q
@@ -2310,30 +2741,74 @@ def process_xp_spend(character, stat_name, new_rating, category, subcategory, re
             cat_subcat = _determine_stat_category(stat_name)
             if cat_subcat:
                 category, subcategory = cat_subcat
+                logger.log_info(f"Determined category: {category}, subcategory: {subcategory} for {stat_name}")
             else:
-                # Try to check if it's a merit or flaw before giving up
-                from world.wod20th.utils.stat_mappings import MERIT_VALUES, FLAW_VALUES
+                # Try to check if it's a merit, flaw, or rite before giving up
+                from world.wod20th.utils.stat_mappings import (
+                    MERIT_VALUES, FLAW_VALUES, MERIT_CATEGORIES, FLAW_CATEGORIES,
+                    RITE_VALUES
+                )
                 
-                # Check merit categories
-                for merit_category, merits in MERIT_VALUES.items():
-                    if stat_name in merits or stat_name.lower() in [m.lower() for m in merits]:
-                        logger.log_info(f"Found merit match: {stat_name} in category {merit_category}")
-                        category = 'merits'
-                        subcategory = merit_category
+                # Check for exact merit/flaw/rite match
+                stat_name_lower = stat_name.lower()
+                
+                # Check for exact rite matches
+                for rite_name in RITE_VALUES.keys():
+                    if rite_name.lower() == stat_name_lower:
+                        category = 'powers'
+                        subcategory = 'rite'
+                        stat_name = rite_name  # Use the correct case
                         break
                 
-                # Check flaw categories
+                # Check for exact merit matches
                 if not category:
-                    for flaw_category, flaws in FLAW_VALUES.items():
-                        if stat_name in flaws or stat_name.lower() in [f.lower() for f in flaws]:
-                            logger.log_info(f"Found flaw match: {stat_name} in category {flaw_category}")
-                            category = 'flaws'
-                            subcategory = flaw_category
+                    for merit_name in MERIT_VALUES.keys():
+                        if merit_name.lower() == stat_name_lower:
+                            if not is_staff_spend:
+                                return False, f"Merits require staff approval. Please use the +request command instead.", 0
+                            category = 'merits'
+                            for merit_category, merits in MERIT_CATEGORIES.items():
+                                if merit_name in merits:
+                                    subcategory = merit_category
+                                    break
+                            if not subcategory:
+                                subcategory = 'physical'  # Default
                             break
+                
+                # Check for exact flaw matches
+                if not category:
+                    for flaw_name in FLAW_VALUES.keys():
+                        if flaw_name.lower() == stat_name_lower:
+                            if not is_staff_spend:
+                                return False, f"Buying off flaws requires staff approval. Please use the +request command instead.", 0
+                            category = 'flaws'
+                            for flaw_category, flaws in FLAW_CATEGORIES.items():
+                                if flaw_name in flaws:
+                                    subcategory = flaw_category
+                                    break
+                            if not subcategory:
+                                subcategory = 'physical'  # Default
+                            break
+                
+                # Special case for Acute Sense(s)
+                if not category and (stat_name_lower == "acute sense" or stat_name_lower == "acute senses"):
+                    if not is_staff_spend:
+                        return False, f"Merits require staff approval. Please use the +request command instead.", 0
+                    category = 'merits'
+                    subcategory = 'physical'
                 
                 # If still not found
                 if not category:
                     return False, f"Could not determine category for {stat_name}", 0
+
+        # Early rejection for merits and flaws for non-staff users
+        if category in ['merits', 'flaws'] and not is_staff_spend:
+            reject_message = "Merits require staff approval" if category == 'merits' else "Buying off flaws requires staff approval"
+            return False, f"{reject_message}. Please use the +request command instead.", 0
+            
+        # Special handling for rites - level 1 rites can be purchased, higher need staff approval
+        if category == 'powers' and subcategory == 'rite' and new_rating > 1 and not is_staff_spend:
+            return False, f"Rites above level 1 require staff approval. Please use the +request command instead.", 0
 
         # Get character's splat and type
         splat = character.db.stats.get('other', {}).get('splat', {}).get('Splat', {}).get('perm', '')
@@ -2341,7 +2816,13 @@ def process_xp_spend(character, stat_name, new_rating, category, subcategory, re
         
         if not splat:
             return False, "Character splat not set", 0
-        
+            
+        # Validate if the stat is appropriate for this character's splat (skip for staff)
+        if not is_staff_spend:
+            is_valid_for_splat, splat_validation_message = validate_stat_for_splat(character, stat_name, category, subcategory)
+            if not is_valid_for_splat:
+                return False, splat_validation_message, 0
+
         # Store the original stat name before normalization
         original_stat_name = stat_name
         
@@ -2383,25 +2864,37 @@ def process_xp_spend(character, stat_name, new_rating, category, subcategory, re
         # Calculate cost based on the category
         logger.log_info(f"Calculating cost for {canonical_gift_name or stat_name}, category: {category}, subcategory: {subcategory}")
         
-        if category == 'merits':
-            # Ensure proper merit cost calculation (5 XP per dot)
-            from world.wod20th.utils.xp_costs import calculate_merit_cost
-            cost = calculate_merit_cost(current_rating, new_rating)
-            logger.log_info(f"Merit cost for {stat_name}: {cost} XP")
-        elif category == 'flaws':
-            # Flaw costs for buying off
-            from world.wod20th.utils.xp_costs import calculate_flaw_cost
-            cost = calculate_flaw_cost(current_rating, new_rating)
-            logger.log_info(f"Flaw buyoff cost for {stat_name}: {cost} XP")
-        else:
-            # Regular cost calculation
-            cost, requires_approval = calculate_xp_cost(
-                character, is_staff_spend, canonical_gift_name or stat_name, category, subcategory, current_rating, new_rating
-            )
-            
-            # Skip approval check for staff spends
-            if requires_approval and not is_staff_spend:
-                return False, f"Staff approval required for {canonical_gift_name or stat_name} at this level", cost
+        # Special check for general gifts FIRST
+        cost = 0
+        requires_approval = False
+        
+        if category == 'powers' and subcategory == 'gift':
+            shifter_type = character.db.stats.get('identity', {}).get('lineage', {}).get('Type', {}).get('perm', '')
+            if shifter_type and shifter_type != 'Garou' and (canonical_gift_name or stat_name) in GENERAL_SHIFTER_GIFTS.get(shifter_type, []):
+                logger.log_info(f"Gift '{canonical_gift_name or stat_name}' is a general gift for {shifter_type}. Using in-breed cost in process_xp_spend.")
+                cost = new_rating * 3
+        
+        # Only calculate using other methods if general gift check didn't set cost
+        if cost == 0:
+            if category == 'merits':
+                # Ensure proper merit cost calculation (5 XP per dot)
+                from world.wod20th.utils.xp_costs import calculate_merit_cost
+                cost = calculate_merit_cost(current_rating, new_rating)
+                logger.log_info(f"Merit cost for {stat_name}: {cost} XP")
+            elif category == 'flaws':
+                # Flaw costs for buying off
+                from world.wod20th.utils.xp_costs import calculate_flaw_cost
+                cost = calculate_flaw_cost(current_rating, new_rating)
+                logger.log_info(f"Flaw buyoff cost for {stat_name}: {cost} XP")
+            else:
+                # Regular cost calculation
+                cost, requires_approval = calculate_xp_cost(
+                    character, is_staff_spend, canonical_gift_name or stat_name, category, subcategory, current_rating, new_rating
+                )
+                
+                # Skip approval check for staff spends
+                if requires_approval and not is_staff_spend:
+                    return False, f"Staff approval required for {canonical_gift_name or stat_name} at this level", cost
         
         # Check if character has enough XP
         current_xp = character.db.xp.get('current', 0)
@@ -3116,3 +3609,153 @@ def validate_stat_requirements(character, stat_name, category, subcategory, new_
         return False, "Kinfolk must purchase or increase the Gnosis merit instead of directly increasing Gnosis pool", current_rating
     
     return True, "Validation passed", current_rating
+
+def validate_stat_for_splat(character, stat_name, category, subcategory):
+    """
+    Validate if a stat is appropriate for a character's splat.
+    
+    Args:
+        character: The character object
+        stat_name: The name of the stat to validate
+        category: The category of the stat
+        subcategory: The subcategory of the stat
+        
+    Returns:
+        tuple: (is_valid, message)
+    """
+    splat = character.db.stats.get('other', {}).get('splat', {}).get('Splat', {}).get('perm', '')
+    char_type = character.db.stats.get('identity', {}).get('lineage', {}).get('Type', {}).get('perm', '')
+    
+    if not splat:
+        return True, ""  # If splat is not set, don't validate
+    
+    # Define splat-specific validation rules
+    # Format: stat_name.lower(): [list of valid splats]
+    stat_name_lower = stat_name.lower()
+    
+    # Special abilities validation
+    SPLAT_SPECIFIC_ABILITIES = {
+        # Shifter-specific
+        'rituals': ['Shifter', 'Mortal+'],  # Mortal+ Kinfolk can buy rituals
+        'rites': ['Shifter', 'Mortal+'],    # Mortal+ Kinfolk can buy rites
+        'primal-urge': ['Shifter'],
+        
+        # Vampire-specific
+        'blood pool': ['Vampire', 'Mortal+'],  # Mortal+ Ghouls can have blood pool
+        'generation': ['Vampire'],
+        'auspex': ['Vampire', 'Mortal+'],      # Mortal+ Ghouls can have auspex
+        'thaumaturgy': ['Vampire', 'Mortal+'], # Mortal+ Ghouls can have thaumaturgy
+        'necromancy': ['Vampire'],
+        
+        # Mage-specific
+        'arete': ['Mage'],
+        'avatar': ['Mage'],
+        'correspondence': ['Mage'],
+        'entropy': ['Mage'],
+        'forces': ['Mage'],
+        'life': ['Mage'],
+        'matter': ['Mage'],
+        'mind': ['Mage'],
+        'prime': ['Mage'],
+        'spirit': ['Mage'],
+        'time': ['Mage'],
+        'dimensional science': ['Mage'],
+        'primal utility': ['Mage'],
+        'data': ['Mage'],
+        
+        # Changeling-specific
+        'glamour': ['Changeling', 'Mortal+'],  # Mortal+ Kinain can have glamour
+        'banality': ['Changeling', 'Mortal+'],
+        'remembrance': ['Changeling'],
+        'chicanery': ['Changeling', 'Mortal+'],
+        'sovereign': ['Changeling', 'Mortal+'],
+        'legerdemain': ['Changeling', 'Mortal+'],
+        'primal': ['Changeling', 'Mortal+'],
+        'wayfare': ['Changeling', 'Mortal+'],
+        'naming': ['Changeling', 'Mortal+'],
+        
+        # General pools
+        'willpower': ['all'],
+        'rage': ['Shifter'],
+        'gnosis': ['Shifter', 'Mage', 'Mortal+']  # Mortal+ Kinfolk with Gnosis merit can have gnosis
+    }
+    
+    # Check if the stat has splat-specific restrictions
+    if stat_name_lower in SPLAT_SPECIFIC_ABILITIES:
+        allowed_splats = SPLAT_SPECIFIC_ABILITIES[stat_name_lower]
+        
+        # Special handling for "all" - always allowed
+        if 'all' in allowed_splats:
+            return True, ""
+        
+        # Check if the character's splat is allowed
+        if splat in allowed_splats:
+            # For Mortal+, check the specific type if needed
+            if splat == 'Mortal+' and stat_name_lower in ['rituals', 'rites', 'gnosis']:
+                # Kinfolk can buy these
+                if char_type != 'Kinfolk':
+                    valid_types = {'rituals': 'Kinfolk', 'rites': 'Kinfolk', 'gnosis': 'Kinfolk'}
+                    return False, f"{stat_name} is only available to {valid_types[stat_name_lower]} characters, not {char_type}."
+            
+            # Check Mortal+ Ghouls for vampire abilities
+            if splat == 'Mortal+' and stat_name_lower in ['blood pool', 'auspex', 'thaumaturgy']:
+                if char_type != 'Ghoul':
+                    valid_types = {'blood pool': 'Ghoul', 'auspex': 'Ghoul', 'thaumaturgy': 'Ghoul'}
+                    return False, f"{stat_name} is only available to {valid_types[stat_name_lower]} characters, not {char_type}."
+            
+            # Check Mortal+ Kinain for changeling abilities
+            if splat == 'Mortal+' and stat_name_lower in ['glamour', 'banality', 'chicanery', 'sovereign', 'legerdemain', 'primal', 'wayfare', 'naming']:
+                if char_type != 'Kinain':
+                    return False, f"{stat_name} is only available to Kinain characters, not {char_type}."
+            
+            return True, ""
+        
+        # If we got here, the splat is not allowed
+        allowed_splats_str = ", ".join([s for s in allowed_splats if s != 'Mortal+'])
+        
+        # Add Mortal+ subtypes if applicable
+        mortal_subtypes = []
+        if 'Mortal+' in allowed_splats:
+            if stat_name_lower in ['rituals', 'rites', 'gnosis']:
+                mortal_subtypes.append('Kinfolk')
+            if stat_name_lower in ['blood pool', 'auspex', 'thaumaturgy']:
+                mortal_subtypes.append('Ghoul')
+            if stat_name_lower in ['glamour', 'banality', 'chicanery', 'sovereign', 'legerdemain', 'primal', 'wayfare', 'naming']:
+                mortal_subtypes.append('Kinain')
+        
+        if mortal_subtypes:
+            allowed_splats_str += " or " + "/".join(mortal_subtypes) if allowed_splats_str else "/".join(mortal_subtypes)
+        
+        return False, f"{stat_name} is only available to {allowed_splats_str} characters, not {splat}."
+    
+    # Handle splat-specific powers by category
+    if category == 'powers':
+        if subcategory == 'sphere' and splat != 'Mage':
+            return False, f"Spheres are only available to Mage characters, not {splat}."
+        
+        if subcategory == 'discipline' and splat not in ['Vampire', 'Mortal+']:
+            # For Mortal+, only Ghouls can have disciplines
+            if splat == 'Mortal+' and char_type != 'Ghoul':
+                return False, f"Disciplines are only available to Vampire or Ghoul characters, not {splat} {char_type}."
+            return False, f"Disciplines are only available to Vampire or Ghoul characters, not {splat}."
+        
+        if subcategory == 'gift' and splat not in ['Shifter', 'Mortal+']:
+            # For Mortal+, only Kinfolk can have gifts
+            if splat == 'Mortal+' and char_type != 'Kinfolk':
+                return False, f"Gifts are only available to Shifter or Kinfolk characters, not {splat} {char_type}."
+            return False, f"Gifts are only available to Shifter or Kinfolk characters, not {splat}."
+        
+        if subcategory == 'art' and splat not in ['Changeling', 'Mortal+']:
+            # For Mortal+, only Kinain can have arts
+            if splat == 'Mortal+' and char_type != 'Kinain':
+                return False, f"Arts are only available to Changeling or Kinain characters, not {splat} {char_type}."
+            return False, f"Arts are only available to Changeling or Kinain characters, not {splat}."
+        
+        if subcategory == 'realm' and splat not in ['Changeling', 'Mortal+']:
+            # For Mortal+, only Kinain can have realms
+            if splat == 'Mortal+' and char_type != 'Kinain':
+                return False, f"Realms are only available to Changeling or Kinain characters, not {splat} {char_type}."
+            return False, f"Realms are only available to Changeling or Kinain characters, not {splat}."
+    
+    # If we reach here, the stat is valid for this splat
+    return True, ""


### PR DESCRIPTION
Updates the following
* Adds player editable group and plot pages to the wiki
* Fixes the Possessed Blessings by setting the appropriate costs
* Fixes a typo in Possessed Merits and Flaws documents
* Updated Gurahl Gifts
* Updated Bastet gifts
* Updates XP utils to manage general gifts for all fera types
* Characters typeclass update to change 'kithain' to 'fae' when a Changeling is looking at another Changeling (Nunnehi and Inanimae are not considered Kithain)
* Modified starting Willpower for all Mortal+ types
* Resolved a traceback error with +notes where it was looking for 1 arguments when we were providing 2 (+note/prove <note>=<player>). Now prove works properly.
* Added functionality for +roll/specialty, which automatically re-rolls any dice that come up as 10 until there are no more 10s.
* Adjusted cost for sorcery, as we had it listed incorrectly (both in code and on the wiki).
* Rites are now accessible with +xp/spend and +xp/staffspend
* Merits and flaws process correctly now with +xp/staffspend